### PR TITLE
Add comprehensive README and developer documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+Developer and agent reference for the `service-remote` project.
+
+## Project overview
+
+`service-remote` is a Node.js (Bun) web server that exposes a mobile-friendly control panel for church services. It bridges three systems:
+
+- **Proclaim** (church presentation software) via a virtual MIDI port (`easymidi`)
+- **OBS Studio** via the obs-websocket v5 protocol (`obs-websocket-js`)
+- **Behringer X32** audio mixer via OSC over UDP (`osc-min` + Node `dgram`)
+
+A single shared in-memory state object is kept up to date and broadcast to all connected browsers over WebSocket whenever it changes.
+
+## Commands
+
+```bash
+bun start          # Start the server
+bun dev            # Start with --watch (auto-restart on file changes)
+bun test           # Run all tests
+bun test:unit      # Run unit tests only (test/unit/)
+bun test:e2e       # Run end-to-end tests only (test/e2e/)
+```
+
+No build step is required. Bun runs CommonJS files directly.
+
+## Architecture
+
+```
+server.js
+  ├── src/config.js          deep-merges config.default.json + config.json
+  ├── src/state.js           in-memory state store; emits updates to ws.js
+  ├── src/ws.js              WebSocket server; broadcasts state to browsers
+  ├── src/routes.js          Express REST handlers (delegates to connections)
+  └── src/connections/
+        obs.js               OBS WebSocket client
+        x32.js               X32 OSC/UDP client
+        proclaim.js          Virtual MIDI port
+```
+
+### State
+
+`src/state.js` exports `get()` and `update(section, patch)`. Every call to `update` merges the patch into `state[section]` and notifies registered listeners (used by `ws.js` to push updates to browsers). The state shape is:
+
+```js
+{
+  obs: {
+    connected: bool,
+    scenes: string[],
+    currentScene: string,
+    streaming: bool,
+    recording: bool,
+    audioSources: [{ name, volume, muted }]
+  },
+  x32: {
+    connected: bool,
+    channels: [{ index, label, fader, muted }]
+  },
+  proclaim: {
+    connected: bool
+  }
+}
+```
+
+### Configuration
+
+`src/config.js` does a recursive deep-merge of `config.default.json` over `config.json` (user file, gitignored). Array values are replaced wholesale, not merged. The `merge` function is also exported for use in tests.
+
+### Connections
+
+Each connection module (`obs.js`, `x32.js`, `proclaim.js`) exports a `connect()` function called once at startup. They handle their own reconnection logic internally:
+
+- **OBS**: reconnects every 5 s on failure/disconnect
+- **X32**: sends `/xremote` keepalive every 8 s; reconnects after 5 s of no response
+- **Proclaim**: one-shot — attempts to open a virtual MIDI port; logs a warning if MIDI is unavailable
+
+### API routes
+
+Defined in `src/routes.js`. All POST endpoints call the appropriate connection method and return `{ ok: true }` or `{ error: message }` with a 500 status.
+
+- `POST /api/obs/scene` `{ scene }`
+- `POST /api/obs/mute` `{ input }`
+- `POST /api/obs/volume` `{ input, volumeDb }`
+- `POST /api/obs/stream`
+- `POST /api/obs/record`
+- `POST /api/x32/fader` `{ channel, value }` (value 0–1)
+- `POST /api/x32/mute` `{ channel }`
+- `POST /api/proclaim/action` `{ action }`
+- `GET /api/state` — returns the full current state
+
+## Testing
+
+Tests use Bun's built-in test runner (`bun:test`). No external test framework is needed.
+
+- `test/unit/` — pure unit tests for `config.js`, `state.js`, and the `parseOscMessage` function in `x32.js`
+- `test/e2e/` — integration tests that spin up the Express app via `supertest` and a real WebSocket server
+- `test/helpers/` — shared utilities (e.g. mock connection factories)
+
+When adding new features:
+1. Unit-test any pure/stateless logic in `test/unit/`.
+2. Add an API test in `test/e2e/api.test.js` for new routes.
+3. Keep connection modules mockable — `routes.js` accepts `{ obs, x32, proclaim }` as an argument so tests can inject stubs.
+
+## Key conventions
+
+- CommonJS (`require`/`module.exports`) throughout — do not introduce ESM.
+- No TypeScript. Keep plain JavaScript.
+- Config is read-only at runtime; never mutate the exported config object.
+- State updates must go through `state.update()` so WebSocket listeners are notified.
+- X32 fader values are 0–1 (linear). OBS volume values are in dB.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,146 @@
+# Service Remote
+
+A mobile-friendly web control panel for running church services. Control Proclaim (presentation software), OBS (streaming), and a Behringer X32 mixer from any device on your local network.
+
+## Features
+
+- **Proclaim** — send next/previous slide and item commands via a virtual MIDI port
+- **OBS** — switch scenes, toggle audio mutes, adjust volumes, start/stop streaming and recording
+- **Behringer X32** — control channel faders and mutes via OSC over UDP
+- Real-time state sync to all connected browsers via WebSocket
+- Mobile-optimised UI served from the same process
+
+## Prerequisites
+
+- [Bun](https://bun.sh) v1.0 or later
+- For Proclaim control: a macOS or Windows machine with native MIDI support (Linux requires a MIDI kernel module)
+- For OBS control: OBS Studio with the obs-websocket plugin enabled
+- For X32 control: Behringer X32 reachable on the local network
+
+## Installation
+
+```bash
+git clone <repo-url>
+cd service-remote
+bun install
+```
+
+## Configuration
+
+Copy `config.default.json` to `config.json` and edit it to match your setup. Values in `config.json` are deep-merged over the defaults, so you only need to include the keys you want to change.
+
+```bash
+cp config.default.json config.json
+```
+
+Key settings:
+
+| Key | Description |
+|-----|-------------|
+| `server.port` | Port the web server listens on (default `3000`) |
+| `obs.address` | WebSocket URL for OBS (default `ws://localhost:4455`) |
+| `obs.password` | obs-websocket password (leave empty if auth is disabled) |
+| `x32.address` | IP address of the X32 mixer |
+| `x32.port` | UDP port of the X32 (default `10023`) |
+| `x32.channels` | Array of `{ index, label }` objects for channels to expose |
+| `proclaim.midiPortName` | Name of the virtual MIDI port to create |
+| `proclaim.actions` | MIDI CC/note-on definitions for each Proclaim action |
+
+### Proclaim MIDI actions
+
+Each action under `proclaim.actions` can be a CC message:
+
+```json
+{ "type": "cc", "channel": 0, "controller": 1, "value": 127 }
+```
+
+or a note-on (automatically followed by note-off after 100 ms):
+
+```json
+{ "type": "noteon", "channel": 0, "note": 60, "velocity": 127 }
+```
+
+The built-in actions are `nextSlide`, `prevSlide`, `nextItem`, and `prevItem`. In Proclaim, map those MIDI messages to the corresponding keyboard shortcuts.
+
+## Running
+
+```bash
+# Production
+bun start
+
+# Development (auto-restarts on file changes)
+bun dev
+```
+
+Open `http://localhost:3000` (or the configured port) on any device on the same network.
+
+The server attempts to connect to OBS, X32, and Proclaim on startup and will automatically reconnect if a connection drops.
+
+## API
+
+All endpoints return JSON. State changes are also pushed to browsers via WebSocket.
+
+### OBS
+
+| Method | Path | Body | Description |
+|--------|------|------|-------------|
+| `POST` | `/api/obs/scene` | `{ "scene": "Scene Name" }` | Switch to a scene |
+| `POST` | `/api/obs/mute` | `{ "input": "Mic" }` | Toggle mute on an input |
+| `POST` | `/api/obs/volume` | `{ "input": "Mic", "volumeDb": -10 }` | Set input volume (dB) |
+| `POST` | `/api/obs/stream` | — | Toggle streaming |
+| `POST` | `/api/obs/record` | — | Toggle recording |
+
+### X32
+
+| Method | Path | Body | Description |
+|--------|------|------|-------------|
+| `POST` | `/api/x32/fader` | `{ "channel": 1, "value": 0.75 }` | Set fader level (0–1) |
+| `POST` | `/api/x32/mute` | `{ "channel": 1 }` | Toggle channel mute |
+
+### Proclaim
+
+| Method | Path | Body | Description |
+|--------|------|------|-------------|
+| `POST` | `/api/proclaim/action` | `{ "action": "nextSlide" }` | Send a configured MIDI action |
+
+### State
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/state` | Full application state (used on initial page load) |
+
+## Testing
+
+```bash
+# All tests
+bun test
+
+# Unit tests only
+bun test:unit
+
+# End-to-end tests only
+bun test:e2e
+```
+
+## Project Structure
+
+```
+server.js            # Entry point — wires together Express, WebSocket, and connections
+config.default.json  # Default configuration (do not edit; override via config.json)
+src/
+  config.js          # Loads and deep-merges config.default.json + config.json
+  state.js           # Shared in-memory state, notifies WebSocket on changes
+  routes.js          # Express route handlers
+  ws.js              # WebSocket server — broadcasts state updates to browsers
+  connections/
+    obs.js           # OBS WebSocket connection and event handling
+    x32.js           # Behringer X32 OSC/UDP connection and event handling
+    proclaim.js      # Proclaim virtual MIDI port
+public/
+  index.html         # Single-page UI
+  style.css          # UI styles
+test/
+  unit/              # Unit tests (config, state, X32 OSC parsing)
+  e2e/               # End-to-end API and WebSocket tests
+  helpers/           # Shared test utilities
+```


### PR DESCRIPTION
## Summary

This PR adds complete user-facing and developer documentation for the `service-remote` project, establishing clear guidance for installation, configuration, usage, and contribution.

## Changes

- **README.md**: Comprehensive user guide covering:
  - Project overview and feature list
  - Prerequisites and installation instructions
  - Configuration guide with all key settings documented
  - Proclaim MIDI action format and examples
  - Running instructions for both production and development
  - Complete REST API reference for OBS, X32, and Proclaim endpoints
  - Testing commands
  - Project structure overview

- **CLAUDE.md**: Developer reference guide including:
  - Project architecture and module responsibilities
  - State management design and shape
  - Configuration loading and merging behavior
  - Connection module patterns (reconnection logic, keepalives)
  - API route specifications
  - Testing strategy and conventions
  - Key development conventions (CommonJS, no TypeScript, state update patterns)

## Notable Details

- Documentation reflects the actual codebase structure and behavior (WebSocket state sync, OSC/UDP for X32, virtual MIDI for Proclaim, obs-websocket v5)
- API documentation includes all request/response formats for easy reference
- Developer guide emphasizes testability patterns and provides clear guidance for adding new features
- Configuration table makes it easy for users to understand all available settings

https://claude.ai/code/session_013tgcuYpMin4ecXFfoQ9W1p