### PR TITLE
Add Windows system tray integration with connection status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: bun install
 
       - name: Build Windows executable
-        run: bun build --compile --target=bun-windows-x64 --external=easymidi ./server.js --outfile service-remote.exe
+        run: bun build --compile --target=bun-windows-x64 --external=easymidi --external=systray ./server.js --outfile service-remote.exe
 
       - name: Package release
         run: |
@@ -46,9 +46,9 @@ jobs:
           Copy-Item service-remote.exe release\
           Copy-Item -Recurse public release\public
           Copy-Item config.default.json release\
-          # Include the native easymidi addon so MIDI support works at runtime.
-          # Bun resolves --external modules from node_modules/ next to the exe.
+          # Include external modules that Bun resolves from node_modules/ next to the exe.
           Copy-Item -Recurse node_modules\easymidi release\node_modules\easymidi
+          Copy-Item -Recurse node_modules\systray release\node_modules\systray
         shell: pwsh
 
       - name: Upload artifact

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "express": "^4.21.0",
         "obs-websocket-js": "^5.0.6",
         "osc-min": "^1.1.2",
+        "systray": "^1.0.5",
         "ws": "^8.18.0",
       },
       "devDependencies": {
@@ -119,6 +120,8 @@
 
     "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
 
+    "fs-extra": ["fs-extra@4.0.3", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
@@ -128,6 +131,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -146,6 +151,8 @@
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
+
+    "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -221,11 +228,15 @@
 
     "supertest": ["supertest@7.2.2", "", { "dependencies": { "cookie-signature": "^1.2.2", "methods": "^1.1.2", "superagent": "^10.3.0" } }, "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA=="],
 
+    "systray": ["systray@1.0.5", "", { "dependencies": { "debug": "^3.0.1", "fs-extra": "^4.0.2" } }, "sha512-qLsl5lk8lUuqCTaREJ0nR6NgF2y2Ni01vBjUs0cVWf54ZeV4pr3TFLMcUT+od1Twb1qQMq/SKyj+BKd2vg6+Fg=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "type-fest": ["type-fest@3.13.1", "", {}, "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="],
 
     "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -255,8 +266,12 @@
 
     "superagent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "systray/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
     "obs-websocket-js/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "superagent/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "systray/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.21.0",
     "obs-websocket-js": "^5.0.6",
     "osc-min": "^1.1.2",
+    "systray": "^1.0.5",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const path = require('path');
 const config = require('./src/config');
 const state = require('./src/state');
+const { startTray } = require('./src/tray');
 const { setupWebSocket } = require('./src/ws');
 const { setupRoutes } = require('./src/routes');
 const obs = require('./src/connections/obs');
@@ -25,4 +26,5 @@ proclaim.connect();
 const port = config.server.port;
 server.listen(port, () => {
   console.log(`Service Remote running at http://localhost:${port}`);
+  startTray(port, state);
 });

--- a/src/tray.js
+++ b/src/tray.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const { exec } = require('child_process');
+
+// Build a minimal 16x16 32-bit ICO in memory so no image file needs to be shipped.
+function buildIcon() {
+  const w = 16, h = 16;
+
+  // BITMAPINFOHEADER (40 bytes)
+  const bih = Buffer.alloc(40);
+  bih.writeUInt32LE(40, 0);       // biSize
+  bih.writeInt32LE(w, 4);         // biWidth
+  bih.writeInt32LE(h * 2, 8);     // biHeight (×2 for ICO AND-mask convention)
+  bih.writeUInt16LE(1, 12);       // biPlanes
+  bih.writeUInt16LE(32, 14);      // biBitCount (32-bit BGRA)
+
+  // Pixel data: 16×16 BGRA, solid blue (#0057A6)
+  const px = Buffer.alloc(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    px[i * 4 + 0] = 0xA6; // B
+    px[i * 4 + 1] = 0x57; // G
+    px[i * 4 + 2] = 0x00; // R
+    px[i * 4 + 3] = 0xFF; // A
+  }
+
+  // AND mask — one bit per pixel, DWORD-aligned rows, all zeros (fully opaque)
+  const andMask = Buffer.alloc(Math.ceil(w / 32) * 4 * h, 0);
+
+  const imgData = Buffer.concat([bih, px, andMask]);
+
+  // ICO file header
+  const icoHdr = Buffer.from([0, 0, 1, 0, 1, 0]);
+
+  // ICO directory entry (16 bytes)
+  const dir = Buffer.alloc(16);
+  dir[0] = w;
+  dir[1] = h;
+  dir.writeUInt16LE(1, 4);               // planes
+  dir.writeUInt16LE(32, 6);              // bitCount
+  dir.writeUInt32LE(imgData.length, 8);  // size of image data
+  dir.writeUInt32LE(22, 12);             // offset (6 header + 16 dir = 22)
+
+  return Buffer.concat([icoHdr, dir, imgData]).toString('base64');
+}
+
+const ICON = buildIcon();
+
+// Menu item indices (no separators — systray has no standard separator API)
+const MENU = {
+  STATUS:       0,  // disabled status-display item, updated on state changes
+  OPEN_BROWSER: 1,
+  EXIT:         2,
+};
+
+function startTray(port, state) {
+  if (process.platform !== 'win32') return;
+
+  let SysTray;
+  try {
+    SysTray = require('systray').default;
+  } catch (e) {
+    console.warn('[Tray] systray module not available:', e.message);
+    return;
+  }
+
+  const tray = new SysTray({
+    menu: {
+      icon: ICON,
+      title: '',
+      tooltip: 'service-remote',
+      items: [
+        { title: 'OBS:off  X32:off  MIDI:off', tooltip: 'Connection status', checked: false, enabled: false },
+        { title: 'Open in Browser', tooltip: '', checked: false, enabled: true },
+        { title: 'Exit', tooltip: '', checked: false, enabled: true },
+      ],
+    },
+    copyDir: true,  // cache the tray binary in the user profile on first run
+    debug: false,
+  });
+
+  tray.onError(err => console.warn('[Tray] error:', err.message));
+
+  tray.onClick(action => {
+    if (action.seq_id === MENU.OPEN_BROWSER) {
+      exec(`start http://localhost:${port}`);
+    } else if (action.seq_id === MENU.EXIT) {
+      tray.kill(); // also calls process.exit(0) once the tray binary exits
+    }
+  });
+
+  // Update the status item whenever any connection state changes
+  state.on('change', ({ state: s }) => {
+    const obs  = s.obs.connected      ? 'OBS:on'  : 'OBS:off';
+    const x32  = s.x32.connected      ? 'X32:on'  : 'X32:off';
+    const midi = s.proclaim.connected ? 'MIDI:on' : 'MIDI:off';
+    tray.sendAction({
+      type: 'update-item',
+      item: { title: `${obs}  ${x32}  ${midi}`, tooltip: 'Connection status', checked: false, enabled: false },
+      seq_id: MENU.STATUS,
+    });
+  });
+
+  // Clean up the tray process if the server exits for any other reason
+  process.on('exit', () => {
+    if (!tray.killed) tray.kill(false);
+  });
+}
+
+module.exports = { startTray };


### PR DESCRIPTION
## Summary
Adds Windows system tray support to display real-time connection status for OBS, X32, and MIDI services, with quick access to open the browser interface and exit the application.

## Key Changes
- **New tray module** (`src/tray.js`): Implements system tray functionality for Windows using the `systray` package
  - Generates a minimal 16×16 32-bit ICO icon in memory (solid blue #0057A6) to avoid shipping image files
  - Provides three menu items: status display, "Open in Browser", and "Exit"
  - Dynamically updates the status item whenever connection state changes
  - Handles graceful cleanup when the server exits
  
- **Server integration** (`server.js`): Initializes the tray on startup with the configured port and state manager

- **Dependencies** (`package.json`): Added `systray` v1.0.5 as a production dependency

- **Build configuration** (`build.yml`): 
  - Marked `systray` as external in the Bun compilation step
  - Updated release packaging to include the `systray` module alongside `easymidi` in `node_modules/`

## Implementation Details
- The tray only activates on Windows (`process.platform === 'win32'`)
- Gracefully handles missing `systray` module with a warning if not available
- Icon is built programmatically using Buffer operations to construct valid ICO file format (header + BITMAPINFOHEADER + BGRA pixel data + AND mask)
- Status display is read-only and updates in real-time by listening to the state change events
- Browser launch uses `start` command (Windows-specific)

https://claude.ai/code/session_0146yf8XPpExn4g4ENUyB76D