### PR TITLE
Fix variable declaration in binpack dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "binpack@0.1.0": "patches/binpack@0.1.0.patch",
+  },
   "packages": {
     "@julusian/midi": ["@julusian/midi@3.6.1", "", { "dependencies": { "node-addon-api": "^6.1.0", "pkg-prebuilds": "^1.0.0" } }, "sha512-sC6tTMAMZsHOQILAv/R0On5tKKhzBQUjdyYWzh9l0UQeNry12CFIyRWK1Mep5xCHWCTUB0w4gxngpciA5PgN/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   },
   "devDependencies": {
     "supertest": "^7.2.2"
+  },
+  "patchedDependencies": {
+    "binpack@0.1.0": "patches/binpack@0.1.0.patch"
   }
 }

--- a/patches/binpack@0.1.0.patch
+++ b/patches/binpack@0.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index d7ed315f898655019cc2e56be5e75352db5889ee..de32b536ccb3a26c98f27827aa741c825a5cbe48 100644
+--- a/index.js
++++ b/index.js
+@@ -50,7 +50,7 @@ addIntBindings(8);
+ addIntBindings(16);
+ addIntBindings(32);
+ 
+-twoToThe32 = Math.pow(2, 32);
++var twoToThe32 = Math.pow(2, 32);
+ 
+ // 64 bit bindings require special care
+ var read64 = function(unsigned){return function(buff, endian){


### PR DESCRIPTION
This PR patches the `binpack@0.1.0` dependency to fix a variable declaration issue.

## Summary
Added a patch to the binpack package that properly declares the `twoToThe32` variable using the `var` keyword, preventing it from being implicitly created as a global variable.

## Changes
- Created `patches/binpack@0.1.0.patch` to fix variable declaration in the binpack package's index.js
- Changed `twoToThe32 = Math.pow(2, 32);` to `var twoToThe32 = Math.pow(2, 32);`
- Updated `package.json` to register the patch in `patchedDependencies`

## Details
This patch ensures proper variable scoping by explicitly declaring `twoToThe32` as a local variable rather than allowing it to leak into the global scope. This is a best practice that prevents potential naming conflicts and improves code maintainability.

https://claude.ai/code/session_01PaWx8K1A7budnS2NMvhc32