### PR TITLE
Remove prev/next item buttons from overview panel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,10 +47,6 @@
             <button class="btn btn-large" onclick="sendAction('PreviousSlide')">&#8592; Slide</button>
             <button class="btn btn-large" onclick="sendAction('NextSlide')">Slide &#8594;</button>
           </div>
-          <div class="control-row" style="margin-top:8px">
-            <button class="btn" onclick="sendAction('PreviousServiceItem')">&#8592; Item</button>
-            <button class="btn" onclick="sendAction('NextServiceItem')">Item &#8594;</button>
-          </div>
         </div>
 
         <!-- OBS preview (read-only) -->


### PR DESCRIPTION
Remove the Prev/Next Item buttons from the Overview panel so it only shows slide navigation. Item navigation remains available in the full Proclaim tab.

Fixes #15

Generated with [Claude Code](https://claude.ai/code)