### PR TITLE
feat: auto-discover X32 channels and mix buses

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Key settings:
 | `obs.password` | obs-websocket password (leave empty if auth is disabled) |
 | `x32.address` | IP address of the X32 mixer |
 | `x32.port` | UDP port of the X32 (default `10023`) |
-| `x32.channels` | Array of `{ index, label }` objects for channels to expose |
 | `proclaim.midiPortName` | Name of the virtual MIDI port to create |
 | `proclaim.actions` | MIDI CC/note-on definitions for each Proclaim action |
 
@@ -94,8 +93,8 @@ All endpoints return JSON. State changes are also pushed to browsers via WebSock
 
 | Method | Path | Body | Description |
 |--------|------|------|-------------|
-| `POST` | `/api/x32/fader` | `{ "channel": 1, "value": 0.75 }` | Set fader level (0–1) |
-| `POST` | `/api/x32/mute` | `{ "channel": 1 }` | Toggle channel mute |
+| `POST` | `/api/x32/fader` | `{ "channel": 1, "type": "ch", "value": 0.75 }` | Set fader level (0–1); `type` is `"ch"` (input channel, default) or `"bus"` (mix bus) |
+| `POST` | `/api/x32/mute` | `{ "channel": 1, "type": "ch" }` | Toggle channel mute; `type` defaults to `"ch"` |
 
 ### Proclaim
 

--- a/config.default.json
+++ b/config.default.json
@@ -9,15 +9,7 @@
   },
   "x32": {
     "address": "192.168.1.100",
-    "port": 10023,
-    "channels": [
-      { "index": 1, "label": "Vocal 1" },
-      { "index": 2, "label": "Vocal 2" },
-      { "index": 3, "label": "Guitar" },
-      { "index": 4, "label": "Keys" },
-      { "index": 5, "label": "Bass" },
-      { "index": 6, "label": "Drums" }
-    ]
+    "port": 10023
   },
   "proclaim": {
     "host": "127.0.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -137,9 +137,7 @@
           <button class="btn" onclick="discoverX32()">Auto-detect</button>
           <span class="discover-status" id="discover-x32-status"></span>
         </div>
-        <h3>Channels</h3>
-        <div id="cfg-x32-channels"></div>
-        <button class="btn" style="margin-top:8px" onclick="addX32Channel()">+ Add Channel</button>
+        <p style="color:var(--fg-dim,#888);font-size:0.85em;margin-top:8px">Channels are discovered automatically from the X32.</p>
       </div>
 
       <div class="settings-section">

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,7 +47,6 @@ function reload(): void {
   const merged = merge(defaultConfig as unknown as Record<string, unknown>, freshUserConfig) as unknown as Config;
   Object.assign(config.obs, merged.obs);
   Object.assign(config.x32, merged.x32);
-  config.x32.channels = merged.x32.channels;
   Object.assign(config.proclaim, merged.proclaim);
 }
 

--- a/src/connections/x32.ts
+++ b/src/connections/x32.ts
@@ -19,11 +19,16 @@ interface OscArg {
 
 interface OscResult {
   index: number;
+  type: 'ch' | 'bus';
   patch: Partial<Channel>;
 }
 
-// Track configured channels with their state — initialized in connect()
+// Dynamically discovered channels
 let channels: Channel[] = [];
+
+// Number of input channels and buses on the X32
+const CH_COUNT = 32;
+const BUS_COUNT = 16;
 
 function connect(): void {
   if (reconnectTimer) clearTimeout(reconnectTimer);
@@ -33,13 +38,8 @@ function connect(): void {
   if (server) server.close();
   if (client) client.close();
 
-  // Re-read config so a reload() takes effect
-  channels = config.x32.channels.map((ch) => ({
-    index: ch.index,
-    label: ch.label,
-    fader: 0,
-    muted: false,
-  }));
+  // Start with empty channels — populated via auto-discovery
+  channels = [];
 
   server = new Server(0, '0.0.0.0');
   server.on('message', (msg: unknown[]) => handleMessage(msg));
@@ -52,12 +52,12 @@ function connect(): void {
   // Subscriptions expire after ~10s; renew periodically
   subscribeInterval = setInterval(subscribeToChanges, 8000);
 
-  // Request initial state for each configured channel
-  for (const ch of channels) {
-    const prefix = channelPrefix(ch.index);
-    sendOsc(`${prefix}/mix/fader`);
-    sendOsc(`${prefix}/mix/on`);
-    sendOsc(`${prefix}/config/name`);
+  // Request names for all input channels and buses — non-empty names indicate active channels
+  for (let i = 1; i <= CH_COUNT; i++) {
+    sendOsc(`${channelPrefix(i, 'ch')}/config/name`);
+  }
+  for (let i = 1; i <= BUS_COUNT; i++) {
+    sendOsc(`${channelPrefix(i, 'bus')}/config/name`);
   }
 
   // If we get responses, we're connected
@@ -75,9 +75,9 @@ function scheduleReconnect(): void {
   reconnectTimer = setTimeout(connect, 5000);
 }
 
-function channelPrefix(index: number): string {
+function channelPrefix(index: number, type: 'ch' | 'bus'): string {
   const padded = String(index).padStart(2, '0');
-  return `/ch/${padded}`;
+  return `/${type}/${padded}`;
 }
 
 function sendOsc(address: string, args?: OscArg[]): void {
@@ -90,23 +90,42 @@ function sendOsc(address: string, args?: OscArg[]): void {
 }
 
 // Pure function: parse an OSC address + args into a channel state patch.
-// Returns { index, patch } or null if the message isn't a recognised channel message.
+// Returns { index, type, patch } or null if the message isn't a recognised channel message.
 function parseOscMessage(address: string, args: OscArg[]): OscResult | null {
-  const faderMatch = address.match(/^\/ch\/(\d+)\/mix\/fader$/);
-  if (faderMatch) {
-    return { index: parseInt(faderMatch[1], 10), patch: { fader: (args?.[0]?.value as number) ?? 0 } };
+  // Input channels: /ch/XX/...
+  const chFaderMatch = address.match(/^\/ch\/(\d+)\/mix\/fader$/);
+  if (chFaderMatch) {
+    return { index: parseInt(chFaderMatch[1], 10), type: 'ch', patch: { fader: (args?.[0]?.value as number) ?? 0 } };
   }
 
-  const muteMatch = address.match(/^\/ch\/(\d+)\/mix\/on$/);
-  if (muteMatch) {
-    return { index: parseInt(muteMatch[1], 10), patch: { muted: ((args?.[0]?.value as number) ?? 1) === 0 } };
+  const chMuteMatch = address.match(/^\/ch\/(\d+)\/mix\/on$/);
+  if (chMuteMatch) {
+    return { index: parseInt(chMuteMatch[1], 10), type: 'ch', patch: { muted: ((args?.[0]?.value as number) ?? 1) === 0 } };
   }
 
-  const nameMatch = address.match(/^\/ch\/(\d+)\/config\/name$/);
-  if (nameMatch) {
+  const chNameMatch = address.match(/^\/ch\/(\d+)\/config\/name$/);
+  if (chNameMatch) {
     const name = args?.[0]?.value as string | undefined;
     if (!name) return null;
-    return { index: parseInt(nameMatch[1], 10), patch: { label: name } };
+    return { index: parseInt(chNameMatch[1], 10), type: 'ch', patch: { label: name } };
+  }
+
+  // Mix buses: /bus/XX/...
+  const busFaderMatch = address.match(/^\/bus\/(\d+)\/mix\/fader$/);
+  if (busFaderMatch) {
+    return { index: parseInt(busFaderMatch[1], 10), type: 'bus', patch: { fader: (args?.[0]?.value as number) ?? 0 } };
+  }
+
+  const busMuteMatch = address.match(/^\/bus\/(\d+)\/mix\/on$/);
+  if (busMuteMatch) {
+    return { index: parseInt(busMuteMatch[1], 10), type: 'bus', patch: { muted: ((args?.[0]?.value as number) ?? 1) === 0 } };
+  }
+
+  const busNameMatch = address.match(/^\/bus\/(\d+)\/config\/name$/);
+  if (busNameMatch) {
+    const name = args?.[0]?.value as string | undefined;
+    if (!name) return null;
+    return { index: parseInt(busNameMatch[1], 10), type: 'bus', patch: { label: name } };
   }
 
   return null;
@@ -124,21 +143,34 @@ function handleMessage(msg: unknown[]): void {
 
   const result = parseOscMessage(address, args);
   if (result) {
-    updateChannel(result.index, result.patch);
+    updateChannel(result.index, result.type, result.patch);
   }
 }
 
-function updateChannel(index: number, patch: Partial<Channel>): void {
-  const ch = channels.find((c) => c.index === index);
-  if (!ch) return;
-  Object.assign(ch, patch);
+function updateChannel(index: number, type: 'ch' | 'bus', patch: Partial<Channel>): void {
+  let ch = channels.find((c) => c.index === index && c.type === type);
+  if (!ch) {
+    // Only create a new channel entry when a name is received (auto-discovery)
+    if (!patch.label) return;
+    ch = { index, type, label: patch.label, fader: 0, muted: false };
+    channels.push(ch);
+    channels.sort((a, b) => {
+      if (a.type !== b.type) return a.type === 'ch' ? -1 : 1;
+      return a.index - b.index;
+    });
+    // Request initial fader/mute state for newly discovered channel
+    const prefix = channelPrefix(index, type);
+    sendOsc(`${prefix}/mix/fader`);
+    sendOsc(`${prefix}/mix/on`);
+  } else {
+    Object.assign(ch, patch);
+  }
   state.update('x32', { connected: true, channels: [...channels] });
 }
 
 function subscribeToChanges(): void {
   for (const ch of channels) {
-    const prefix = channelPrefix(ch.index);
-    // X32 /subscribe format: address, param type, fader range, update interval (ms)
+    const prefix = channelPrefix(ch.index, ch.type);
     sendOsc('/subscribe', [
       { value: `${prefix}/mix/fader` },
       { value: 20 },
@@ -164,21 +196,21 @@ export = {
   connect,
   disconnect,
 
-  setFader(channelIndex: number, value: number): void {
+  setFader(channelIndex: number, value: number, type: 'ch' | 'bus' = 'ch'): void {
     const clamped = Math.max(0, Math.min(1, value));
-    sendOsc(`${channelPrefix(channelIndex)}/mix/fader`, [
+    sendOsc(`${channelPrefix(channelIndex, type)}/mix/fader`, [
       { value: clamped },
     ]);
-    updateChannel(channelIndex, { fader: clamped });
+    updateChannel(channelIndex, type, { fader: clamped });
   },
 
-  toggleMute(channelIndex: number): void {
-    const ch = channels.find((c) => c.index === channelIndex);
+  toggleMute(channelIndex: number, type: 'ch' | 'bus' = 'ch'): void {
+    const ch = channels.find((c) => c.index === channelIndex && c.type === type);
     if (!ch) return;
     const newState = ch.muted ? 1 : 0; // 1 = on (unmuted), 0 = off (muted)
-    sendOsc(`${channelPrefix(channelIndex)}/mix/on`, [
+    sendOsc(`${channelPrefix(channelIndex, type)}/mix/on`, [
       { value: newState },
     ]);
-    updateChannel(channelIndex, { muted: !ch.muted });
+    updateChannel(channelIndex, type, { muted: !ch.muted });
   },
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -60,7 +60,7 @@ function setupRoutes(app: Application, { obs, x32, proclaim }: Connections, stat
   // --- X32 ---
   app.post('/api/x32/fader', (req: Request, res: Response) => {
     try {
-      x32.setFader(req.body.channel, req.body.value);
+      x32.setFader(req.body.channel, req.body.value, req.body.type || 'ch');
       res.json({ ok: true });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
@@ -69,7 +69,7 @@ function setupRoutes(app: Application, { obs, x32, proclaim }: Connections, stat
 
   app.post('/api/x32/mute', (req: Request, res: Response) => {
     try {
-      x32.toggleMute(req.body.channel);
+      x32.toggleMute(req.body.channel, req.body.type || 'ch');
       res.json({ ok: true });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
@@ -140,7 +140,7 @@ function setupRoutes(app: Application, { obs, x32, proclaim }: Connections, stat
   app.post('/api/config', async (req: Request, res: Response) => {
     const body = req.body as {
       obs?: { address?: string; password?: string; screenshotInterval?: number };
-      x32?: { address?: string; port?: number; channels?: unknown[] };
+      x32?: { address?: string; port?: number };
       proclaim?: { host?: string; port?: number; password?: string; pollInterval?: number };
     };
     if (!body.obs || !body.x32 || !body.proclaim) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface AudioSource {
 
 export interface Channel {
   index: number;
+  type: 'ch' | 'bus';
   label: string;
   fader: number;
   muted: boolean;
@@ -48,11 +49,6 @@ export interface AppState {
   proclaim: ProclaimState;
 }
 
-export interface ChannelConfig {
-  index: number;
-  label: string;
-}
-
 export interface Config {
   server: {
     port: number;
@@ -65,7 +61,6 @@ export interface Config {
   x32: {
     address: string;
     port: number;
-    channels: ChannelConfig[];
   };
   proclaim: {
     host: string;
@@ -89,9 +84,9 @@ export interface ObsConnection {
 export interface X32Connection {
   connect(): void;
   disconnect(): void;
-  setFader(channelIndex: number, value: number): void;
-  toggleMute(channelIndex: number): void;
-  parseOscMessage(address: string, args: Array<{ value: unknown }>): { index: number; patch: Partial<Channel> } | null;
+  setFader(channelIndex: number, value: number, type?: 'ch' | 'bus'): void;
+  toggleMute(channelIndex: number, type?: 'ch' | 'bus'): void;
+  parseOscMessage(address: string, args: Array<{ value: unknown }>): { index: number; type: 'ch' | 'bus'; patch: Partial<Channel> } | null;
 }
 
 export interface ProclaimConnection {

--- a/test/e2e/api.test.ts
+++ b/test/e2e/api.test.ts
@@ -171,7 +171,6 @@ describe('API routes', () => {
       assert.ok('proclaim' in res.body);
       assert.ok('address' in res.body.obs);
       assert.ok('address' in res.body.x32);
-      assert.ok(Array.isArray(res.body.x32.channels));
     });
   });
 
@@ -187,7 +186,7 @@ describe('API routes', () => {
       const cfgRes = await request.get('/api/config');
       const cfg = cfgRes.body as {
         obs: { address: string; password: string };
-        x32: { address: string; port: number; channels: unknown[] };
+        x32: { address: string; port: number };
         proclaim: { host: string; port: number; password: string };
       };
 

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -49,8 +49,8 @@ function createTestApp(): TestApp {
     x32: {
       connect: () => { calls.x32.connect = (calls.x32.connect as number || 0) as number + 1; },
       disconnect: () => { calls.x32.disconnect = (calls.x32.disconnect as number || 0) as number + 1; },
-      setFader: (channel: number, value: number) => { calls.x32.setFader = { channel, value }; },
-      toggleMute: (channel: number) => { calls.x32.toggleMute = channel; },
+      setFader: (channel: number, value: number, _type?: 'ch' | 'bus') => { calls.x32.setFader = { channel, value }; },
+      toggleMute: (channel: number, _type?: 'ch' | 'bus') => { calls.x32.toggleMute = channel; },
       parseOscMessage: () => null,
     },
     proclaim: {

--- a/test/unit/x32.test.ts
+++ b/test/unit/x32.test.ts
@@ -7,46 +7,46 @@ describe('x32 parseOscMessage()', () => {
   describe('fader messages (/ch/XX/mix/fader)', () => {
     test('single-digit channel is zero-padded', () => {
       const result = parseOscMessage('/ch/01/mix/fader', [{ value: 0.75 }]);
-      assert.deepEqual(result, { index: 1, patch: { fader: 0.75 } });
+      assert.deepEqual(result, { index: 1, type: 'ch', patch: { fader: 0.75 } });
     });
 
     test('two-digit channel', () => {
       const result = parseOscMessage('/ch/16/mix/fader', [{ value: 0.5 }]);
-      assert.deepEqual(result, { index: 16, patch: { fader: 0.5 } });
+      assert.deepEqual(result, { index: 16, type: 'ch', patch: { fader: 0.5 } });
     });
 
     test('fader at zero', () => {
       const result = parseOscMessage('/ch/02/mix/fader', [{ value: 0 }]);
-      assert.deepEqual(result, { index: 2, patch: { fader: 0 } });
+      assert.deepEqual(result, { index: 2, type: 'ch', patch: { fader: 0 } });
     });
 
     test('missing args defaults fader to 0', () => {
       const result = parseOscMessage('/ch/03/mix/fader', []);
-      assert.deepEqual(result, { index: 3, patch: { fader: 0 } });
+      assert.deepEqual(result, { index: 3, type: 'ch', patch: { fader: 0 } });
     });
   });
 
   describe('mute messages (/ch/XX/mix/on)', () => {
     test('value 0 means muted', () => {
       const result = parseOscMessage('/ch/01/mix/on', [{ value: 0 }]);
-      assert.deepEqual(result, { index: 1, patch: { muted: true } });
+      assert.deepEqual(result, { index: 1, type: 'ch', patch: { muted: true } });
     });
 
     test('value 1 means not muted', () => {
       const result = parseOscMessage('/ch/01/mix/on', [{ value: 1 }]);
-      assert.deepEqual(result, { index: 1, patch: { muted: false } });
+      assert.deepEqual(result, { index: 1, type: 'ch', patch: { muted: false } });
     });
 
     test('missing args defaults to not muted', () => {
       const result = parseOscMessage('/ch/04/mix/on', []);
-      assert.deepEqual(result, { index: 4, patch: { muted: false } });
+      assert.deepEqual(result, { index: 4, type: 'ch', patch: { muted: false } });
     });
   });
 
   describe('name messages (/ch/XX/config/name)', () => {
     test('returns label patch for non-empty name', () => {
       const result = parseOscMessage('/ch/03/config/name', [{ value: 'Drums' }]);
-      assert.deepEqual(result, { index: 3, patch: { label: 'Drums' } });
+      assert.deepEqual(result, { index: 3, type: 'ch', patch: { label: 'Drums' } });
     });
 
     test('returns null for empty string name', () => {
@@ -56,6 +56,52 @@ describe('x32 parseOscMessage()', () => {
 
     test('returns null when args are missing', () => {
       const result = parseOscMessage('/ch/03/config/name', []);
+      assert.equal(result, null);
+    });
+  });
+
+  describe('bus fader messages (/bus/XX/mix/fader)', () => {
+    test('bus fader returns type bus', () => {
+      const result = parseOscMessage('/bus/01/mix/fader', [{ value: 0.6 }]);
+      assert.deepEqual(result, { index: 1, type: 'bus', patch: { fader: 0.6 } });
+    });
+
+    test('two-digit bus', () => {
+      const result = parseOscMessage('/bus/16/mix/fader', [{ value: 0.3 }]);
+      assert.deepEqual(result, { index: 16, type: 'bus', patch: { fader: 0.3 } });
+    });
+
+    test('missing args defaults bus fader to 0', () => {
+      const result = parseOscMessage('/bus/02/mix/fader', []);
+      assert.deepEqual(result, { index: 2, type: 'bus', patch: { fader: 0 } });
+    });
+  });
+
+  describe('bus mute messages (/bus/XX/mix/on)', () => {
+    test('value 0 means bus muted', () => {
+      const result = parseOscMessage('/bus/01/mix/on', [{ value: 0 }]);
+      assert.deepEqual(result, { index: 1, type: 'bus', patch: { muted: true } });
+    });
+
+    test('value 1 means bus not muted', () => {
+      const result = parseOscMessage('/bus/01/mix/on', [{ value: 1 }]);
+      assert.deepEqual(result, { index: 1, type: 'bus', patch: { muted: false } });
+    });
+  });
+
+  describe('bus name messages (/bus/XX/config/name)', () => {
+    test('returns label patch for non-empty bus name', () => {
+      const result = parseOscMessage('/bus/03/config/name', [{ value: 'IEM Mix' }]);
+      assert.deepEqual(result, { index: 3, type: 'bus', patch: { label: 'IEM Mix' } });
+    });
+
+    test('returns null for empty bus name', () => {
+      const result = parseOscMessage('/bus/03/config/name', [{ value: '' }]);
+      assert.equal(result, null);
+    });
+
+    test('returns null when bus name args are missing', () => {
+      const result = parseOscMessage('/bus/03/config/name', []);
       assert.equal(result, null);
     });
   });


### PR DESCRIPTION
Closes #12

On connect, query all 32 input channels and 16 mix buses for their names. Only channels with a non-empty name configured on the X32 appear in the UI — no manual config needed.

Also adds mix bus support throughout: OSC parsing, state, routes, and the frontend all handle `type: 'ch' | 'bus'` alongside the channel index.

Generated with [Claude Code](https://claude.ai/code)