### PR TITLE
fix: use full-list index for GoToServiceItem to fix wrong item navigation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -255,12 +255,11 @@ function renderProclaim(p) {
   setThumb(document.getElementById('proclaim-thumb-current'), p.currentItemId, slideIndex);
   setThumb(document.getElementById('proclaim-thumb-next'), nextItemId, nextSlideIndex);
 
-  // Service item list — find position in full (unfiltered) list for GoToServiceItem
-  // We pass 1-based index into the filtered list (Proclaim uses 1-based)
+  // Service item list — use the original full-list 1-based index for GoToServiceItem
   itemsEl.innerHTML = items
-    .map((item, i) => {
+    .map((item) => {
       const isActive = item.id === p.currentItemId;
-      return `<button class="item-btn${isActive ? ' active' : ''}" onclick="sendAction('GoToServiceItem', ${i + 1})">${esc(item.title || item.kind)}</button>`;
+      return `<button class="item-btn${isActive ? ' active' : ''}" onclick="sendAction('GoToServiceItem', ${item.index})">${esc(item.title || item.kind)}</button>`;
     })
     .join('');
 }

--- a/src/connections/proclaim.ts
+++ b/src/connections/proclaim.ts
@@ -266,12 +266,14 @@ async function fetchDetailedStatus(): Promise<void> {
 
     const rawItems = (presentationCache as any)?.serviceItems ?? [];
     const serviceItems: ServiceItem[] = rawItems
-      .filter((item: any) => !EXCLUDED_KINDS.has(item.kind))
-      .map((item: any) => ({
+      .map((item: any, i: number) => ({ item, rawIndex: i + 1 }))
+      .filter(({ item }: { item: any }) => !EXCLUDED_KINDS.has(item.kind))
+      .map(({ item, rawIndex }: { item: any; rawIndex: number }) => ({
         id: item.id,
         title: item.title,
         kind: item.kind,
         slideCount: item.slides ? item.slides.length : 0,
+        index: rawIndex,
       }));
 
     const currentItem = serviceItems.find((item) => item.id === status.itemId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface ServiceItem {
   title: string;
   kind: string;
   slideCount: number;
+  index: number; // 1-based position in the full (unfiltered) Proclaim service item list
 }
 
 export interface ObsState {

--- a/test/unit/proclaim.test.js
+++ b/test/unit/proclaim.test.js
@@ -164,6 +164,83 @@ describe('proclaim.sendAction', () => {
   });
 });
 
+describe('proclaim service item indexing', () => {
+  afterEach(() => {
+    delete globalThis.fetch;
+    for (const key of Object.keys(require.cache)) {
+      if (key.includes('connections/proclaim') || key.includes('src/state')) {
+        delete require.cache[key];
+      }
+    }
+  });
+
+  test('preserves full-list 1-based index when excluded items are interspersed', async () => {
+    const presentation = {
+      id: 'pres1',
+      localRevision: 1,
+      serviceItems: [
+        { id: 'item1', title: 'Song', kind: 'Song', slides: [{ index: 0, localRevision: 1 }] },
+        { id: 'item2', title: 'Grouping', kind: 'Grouping', slides: [] },
+        { id: 'item3', title: 'Prayer', kind: 'Prayer', slides: [{ index: 0, localRevision: 2 }] },
+        { id: 'item4', title: 'Stage Direction', kind: 'StageDirectionCue', slides: [] },
+        { id: 'item5', title: 'Hymn', kind: 'Song', slides: [{ index: 0, localRevision: 3 }] },
+      ],
+    };
+    const statusResponse = {
+      presentationId: 'pres1',
+      presentationLocalRevision: 1,
+      status: { itemId: 'item1', slideIndex: 0 },
+    };
+
+    globalThis.fetch = async (url) => {
+      if (url.includes('authenticate')) {
+        return { ok: true, status: 200, json: async () => ({ proclaimAuthToken: 'tok' }), text: async () => '' };
+      }
+      if (url.includes('onair/session')) {
+        return { ok: true, status: 200, json: async () => 'sess1', text: async () => 'sess1' };
+      }
+      if (url.includes('auth/control')) {
+        return { ok: true, status: 200, json: async () => ({ connectionId: 'conn1' }), text: async () => JSON.stringify({ connectionId: 'conn1' }) };
+      }
+      if (url.includes('presentations/onair') && !url.includes('items')) {
+        return { ok: true, status: 200, text: async () => JSON.stringify(presentation) };
+      }
+      if (url.includes('statusChanged')) {
+        return { ok: true, status: 200, text: async () => JSON.stringify(statusResponse) };
+      }
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '{}' };
+    };
+
+    const proclaim = freshProclaim();
+    const state = require('../../src/state');
+    const updates = [];
+    state.on('change', ({ section, state: s }) => {
+      if (section === 'proclaim') updates.push(JSON.parse(JSON.stringify(s.proclaim)));
+    });
+
+    await proclaim.connect();
+    await new Promise((r) => setTimeout(r, 100));
+
+    const updateWithItems = updates.find((u) => u.serviceItems && u.serviceItems.length > 0);
+    assert.ok(updateWithItems, 'Expected a state update with serviceItems');
+
+    const items = updateWithItems.serviceItems;
+    assert.equal(items.length, 3, 'Should have 3 items after filtering out Grouping and StageDirectionCue');
+
+    // Song is at raw index 1
+    assert.equal(items[0].id, 'item1');
+    assert.equal(items[0].index, 1);
+
+    // Prayer is at raw index 3 (Grouping at index 2 was excluded)
+    assert.equal(items[1].id, 'item3');
+    assert.equal(items[1].index, 3);
+
+    // Hymn is at raw index 5 (StageDirectionCue at index 4 was excluded)
+    assert.equal(items[2].id, 'item5');
+    assert.equal(items[2].index, 5);
+  });
+});
+
 describe('proclaim._pollStatus', () => {
   afterEach(() => {
     delete globalThis.fetch;


### PR DESCRIPTION
When service items are filtered (excluding Grouping and StageDirectionCue), the frontend was using the filtered list position as the GoToServiceItem index. Proclaim expects the index in the full unfiltered list, so clicking a filtered item would navigate to the wrong position.

Fix by storing the 1-based full-list position as `index` in each ServiceItem and using that value when sending the GoToServiceItem command.

Fixes #23

Generated with [Claude Code](https://claude.ai/code)