### PR TITLE
feat: restructure overview panel as 2-column grid

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -324,6 +324,24 @@ function renderOverview(s) {
     </div>`
     )
     .join('');
+
+  // OBS audio compact levels — read-only volume bars (dB normalized to 0–1)
+  const obsAudioEl = document.getElementById('ov-obs-audio');
+  if (obsAudioEl) {
+    obsAudioEl.innerHTML = s.obs.audioSources
+      .map((src) => {
+        const vol = src.volume != null && isFinite(src.volume) ? src.volume : -60;
+        const barWidth = ((vol + 60) / 60 * 100).toFixed(1);
+        return `
+    <div class="ov-channel-row">
+      <span class="ov-ch-label${src.muted ? ' muted' : ''}">${esc(src.name)}</span>
+      <div class="ov-fader-bar">
+        <div class="ov-fader-fill${src.muted ? ' muted' : ''}" style="width:${barWidth}%"></div>
+      </div>
+    </div>`;
+      })
+      .join('');
+  }
 }
 
 function renderOverviewProclaim(p) {

--- a/public/index.html
+++ b/public/index.html
@@ -34,34 +34,35 @@
     <!-- Overview Panel -->
     <section id="panel-overview" class="panel active">
       <div class="overview-grid">
-        <!-- Proclaim -->
-        <div class="ov-block ov-proclaim">
-          <div class="ov-title">Proclaim</div>
-          <div class="slide-strip">
-            <div class="slide-thumb" id="ov-thumb-prev"></div>
-            <div class="slide-thumb active" id="ov-thumb-current"></div>
-            <div class="slide-thumb" id="ov-thumb-next"></div>
-          </div>
-          <div id="ov-now-playing" class="proclaim-now-playing"></div>
-          <div class="control-row">
-            <button class="btn btn-large" onclick="sendAction('PreviousSlide')">&#8592; Slide</button>
-            <button class="btn btn-large" onclick="sendAction('NextSlide')">Slide &#8594;</button>
-          </div>
-        </div>
-
-        <!-- OBS preview (read-only) -->
-        <div class="ov-block ov-obs">
-          <div class="ov-title">OBS &mdash; <span id="ov-current-scene"></span></div>
-          <div class="ov-obs-preview-wrap">
-            <img id="ov-obs-preview" class="ov-obs-preview" src="" alt="Program">
-          </div>
+        <!-- Row 1: Slide description | OBS scene -->
+        <div class="ov-cell ov-slide-desc" id="ov-now-playing"></div>
+        <div class="ov-cell ov-scene-info">
+          <span id="ov-current-scene" class="ov-scene-name"></span>
           <div id="ov-stream-status" class="ov-status-row"></div>
         </div>
 
-        <!-- X32 mix levels (read-only) -->
-        <div class="ov-block ov-x32">
+        <!-- Row 2: Proclaim current slide | OBS Program -->
+        <div class="slide-thumb active" id="ov-thumb-current"></div>
+        <div class="ov-obs-preview-wrap">
+          <img id="ov-obs-preview" class="ov-obs-preview" src="" alt="Program">
+        </div>
+
+        <!-- Row 3: Prev Slide button | Next Slide button -->
+        <button class="btn btn-large" onclick="sendAction('PreviousSlide')">&#8592; Slide</button>
+        <button class="btn btn-large" onclick="sendAction('NextSlide')">Slide &#8594;</button>
+
+        <!-- Row 4: Prev slide thumb | Next slide thumb -->
+        <div class="slide-thumb" id="ov-thumb-prev"></div>
+        <div class="slide-thumb" id="ov-thumb-next"></div>
+
+        <!-- Row 5: Mix levels | OBS levels -->
+        <div class="ov-block">
           <div class="ov-title">Mix</div>
           <div id="ov-channels" class="ov-channel-list"></div>
+        </div>
+        <div class="ov-block">
+          <div class="ov-title">OBS</div>
+          <div id="ov-obs-audio" class="ov-channel-list"></div>
         </div>
       </div>
     </section>

--- a/public/style.css
+++ b/public/style.css
@@ -430,10 +430,41 @@ main {
 
 /* ---- Overview panel ---- */
 .overview-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding: 12px;
+}
+
+/* Info cells (Row 1) */
+.ov-cell {
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 8px 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 12px;
+  justify-content: center;
+  min-height: 44px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.ov-scene-info {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.ov-scene-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* Slide thumbs fill their grid cell */
+.overview-grid .slide-thumb {
+  max-width: 100%;
+  flex: none;
 }
 
 .ov-block {
@@ -461,9 +492,9 @@ main {
   margin-bottom: 10px;
 }
 
-/* Limit preview height on the overview panel */
-.ov-obs .ov-obs-preview-wrap {
-  max-height: 200px;
+/* Remove bottom margin when preview is a direct grid cell */
+.overview-grid .ov-obs-preview-wrap {
+  margin-bottom: 0;
 }
 
 .ov-obs-preview {
@@ -471,10 +502,6 @@ main {
   height: 100%;
   object-fit: contain;
   display: block;
-}
-
-.ov-scenes {
-  margin-bottom: 0;
 }
 
 /* X32 compact channel list */


### PR DESCRIPTION
Implements the layout from issue #24:

- Row 1: Slide description | OBS scene name
- Row 2: Current Proclaim slide | OBS Program preview
- Row 3: Prev Slide button | Next Slide button
- Row 4: Prev slide thumb | Next slide thumb
- Row 5: Mix levels (X32) | OBS audio levels

Also adds read-only OBS audio level bars to the overview panel.

Closes #24

Generated with [Claude Code](https://claude.ai/code)