### PR TITLE
feat: improve service overview with groupings and slide counts

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -256,27 +256,20 @@ function renderProclaim(p) {
   setThumb(document.getElementById('proclaim-thumb-next'), nextItemId, nextSlideIndex);
 
   // Service item list — use the original full-list 1-based index for GoToServiceItem
-  const hasTopLevelSections = p.warmupStartIndex != null || p.serviceStartIndex != null || p.postServiceStartIndex != null;
-  function getTopLevelSection(rawIdx) {
-    if (p.postServiceStartIndex != null && rawIdx >= p.postServiceStartIndex) return 'Post-Service';
-    if (p.serviceStartIndex != null && rawIdx >= p.serviceStartIndex) return 'Service';
-    if (p.warmupStartIndex != null && rawIdx >= p.warmupStartIndex) return 'Warmup';
-    return 'Pre-Service';
-  }
-
-  let currentTopSection = null;
+  let currentSection = null;
+  let currentGroup = null;
   const parts = [];
   for (const item of items) {
-    if (hasTopLevelSections) {
-      const section = getTopLevelSection(item.index - 1);
-      if (section !== currentTopSection) {
-        currentTopSection = section;
-        parts.push(`<div class="item-section-header">${esc(section)}</div>`);
-      }
+    if (item.section !== currentSection) {
+      currentSection = item.section;
+      currentGroup = null;
+      parts.push(`<div class="item-section-header">${esc(item.section)}</div>`);
     }
-    if (item.kind === 'Grouping') {
-      parts.push(`<div class="item-group-header">${esc(item.title || item.kind)}</div>`);
-      continue;
+    if (item.group !== currentGroup) {
+      currentGroup = item.group;
+      if (currentGroup) {
+        parts.push(`<div class="item-group-header">${esc(currentGroup)}</div>`);
+      }
     }
     const isActive = item.id === p.currentItemId;
     let slideCountLabel = '';
@@ -287,7 +280,8 @@ function renderProclaim(p) {
         slideCountLabel = ` <span class="item-slide-count">(${item.slideCount} slides)</span>`;
       }
     }
-    parts.push(`<button class="item-btn${isActive ? ' active' : ''}" onclick="sendAction('GoToServiceItem', ${item.index})">${esc(item.title || item.kind)}${slideCountLabel}</button>`);
+    const indentClass = item.group ? ' item-grouped' : '';
+    parts.push(`<button class="item-btn${isActive ? ' active' : ''}${indentClass}" onclick="sendAction('GoToServiceItem', ${item.index})">${esc(item.title || item.kind)}${slideCountLabel}</button>`);
   }
   itemsEl.innerHTML = parts.join('');
 }

--- a/public/style.css
+++ b/public/style.css
@@ -257,18 +257,16 @@ main {
 }
 
 .item-group-header {
-  padding: 10px 16px 4px;
+  padding: 6px 16px 2px;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text-dim);
-  border-top: 1px solid var(--accent);
   margin-top: 4px;
 }
 
-.item-group-header:first-child {
-  border-top: none;
-  margin-top: 0;
+.item-grouped {
+  margin-left: 12px;
 }
 
 .item-slide-count {

--- a/src/connections/proclaim.ts
+++ b/src/connections/proclaim.ts
@@ -265,22 +265,39 @@ async function fetchDetailedStatus(): Promise<void> {
     }
 
     const rawItems = (presentationCache as any)?.serviceItems ?? [];
-    const serviceItems: ServiceItem[] = rawItems
-      .map((item: any, i: number) => ({ item, rawIndex: i + 1 }))
-      .filter(({ item }: { item: any }) =>
-        !EXCLUDED_KINDS.has(item.kind) &&
-        !(item.kind === 'Grouping' && item.title === 'Slide Group')
-      )
-      .map(({ item, rawIndex }: { item: any; rawIndex: number }) => ({
+    const cache = presentationCache as any;
+    const warmupStartIndex: number | null = cache?.warmupStartIndex ?? null;
+    const serviceStartIndex: number | null = cache?.serviceStartIndex ?? null;
+    const postServiceStartIndex: number | null = cache?.postServiceStartIndex ?? null;
+
+    function getSection(zeroBasedIdx: number): string {
+      if (postServiceStartIndex != null && zeroBasedIdx >= postServiceStartIndex) return 'Post-Service';
+      if (serviceStartIndex != null && zeroBasedIdx >= serviceStartIndex) return 'Service';
+      if (warmupStartIndex != null && zeroBasedIdx >= warmupStartIndex) return 'Warmup';
+      return 'Pre-Service';
+    }
+
+    let currentGroup: string | null = null;
+    const serviceItems: ServiceItem[] = [];
+    for (let i = 0; i < rawItems.length; i++) {
+      const item = rawItems[i];
+      if (EXCLUDED_KINDS.has(item.kind)) continue;
+      if (item.kind === 'Grouping') {
+        currentGroup = item.title === 'Slide Group' ? null : item.title;
+        continue;
+      }
+      serviceItems.push({
         id: item.id,
         title: item.title,
         kind: item.kind,
         slideCount: item.slides ? item.slides.length : 0,
-        index: rawIndex,
-      }));
+        index: i + 1,
+        section: getSection(i),
+        group: currentGroup,
+      });
+    }
 
     const currentItem = serviceItems.find((item) => item.id === status.itemId);
-    const cache = presentationCache as any;
 
     state.update('proclaim', {
       currentItemId: status.itemId || null,
@@ -288,9 +305,6 @@ async function fetchDetailedStatus(): Promise<void> {
       currentItemType: currentItem ? currentItem.kind : null,
       slideIndex: status.slideIndex !== undefined ? status.slideIndex : null,
       serviceItems,
-      warmupStartIndex: cache?.warmupStartIndex ?? null,
-      serviceStartIndex: cache?.serviceStartIndex ?? null,
-      postServiceStartIndex: cache?.postServiceStartIndex ?? null,
     });
   } catch (err) {
     logger.log('[Proclaim] statusChanged error:', (err as Error).message);

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface ServiceItem {
   kind: string;
   slideCount: number;
   index: number; // 1-based position in the full (unfiltered) Proclaim service item list
+  section: string; // e.g. 'Pre-Service', 'Warmup', 'Service', 'Post-Service'
+  group: string | null; // name of the containing Grouping item, or null
 }
 
 export interface ObsState {
@@ -43,9 +45,6 @@ export interface ProclaimState {
   currentItemType: string | null;
   slideIndex: number | null;
   serviceItems: ServiceItem[];
-  warmupStartIndex: number | null;
-  serviceStartIndex: number | null;
-  postServiceStartIndex: number | null;
 }
 
 export interface AppState {

--- a/test/unit/proclaim.test.js
+++ b/test/unit/proclaim.test.js
@@ -228,29 +228,30 @@ describe('proclaim service item indexing', () => {
     assert.ok(updateWithItems, 'Expected a state update with serviceItems');
 
     const items = updateWithItems.serviceItems;
-    assert.equal(items.length, 4, 'Should have 4 items after filtering out only StageDirectionCue (Grouping is included as section header)');
+    assert.equal(items.length, 3, 'Should have 3 items after filtering out StageDirectionCue and Grouping items');
 
-    // Song is at raw index 1
+    // Song is at raw index 1, 0-based index 0 < warmupStartIndex(2) → Pre-Service, no group
     assert.equal(items[0].id, 'item1');
     assert.equal(items[0].index, 1);
+    assert.equal(items[0].section, 'Pre-Service');
+    assert.equal(items[0].group, null);
 
-    // Grouping is at raw index 2 (now included as section header)
-    assert.equal(items[1].id, 'item2');
-    assert.equal(items[1].index, 2);
-    assert.equal(items[1].kind, 'Grouping');
+    // Prayer is at raw index 3, 0-based index 2 >= warmupStartIndex(2) → Warmup, group='Grouping' (set by item2)
+    assert.equal(items[1].id, 'item3');
+    assert.equal(items[1].index, 3);
+    assert.equal(items[1].section, 'Warmup');
+    assert.equal(items[1].group, 'Grouping');
 
-    // Prayer is at raw index 3
-    assert.equal(items[2].id, 'item3');
-    assert.equal(items[2].index, 3);
+    // Hymn is at raw index 5, 0-based index 4 >= serviceStartIndex(4) → Service, group='Grouping' (still active)
+    assert.equal(items[2].id, 'item5');
+    assert.equal(items[2].index, 5);
+    assert.equal(items[2].section, 'Service');
+    assert.equal(items[2].group, 'Grouping');
 
-    // Hymn is at raw index 5 (StageDirectionCue at index 4 was excluded)
-    assert.equal(items[3].id, 'item5');
-    assert.equal(items[3].index, 5);
-
-    // Section indices should be passed through to state
-    assert.equal(updateWithItems.warmupStartIndex, 2);
-    assert.equal(updateWithItems.serviceStartIndex, 4);
-    assert.equal(updateWithItems.postServiceStartIndex, 10);
+    // Section indices are no longer separate state fields
+    assert.equal(updateWithItems.warmupStartIndex, undefined);
+    assert.equal(updateWithItems.serviceStartIndex, undefined);
+    assert.equal(updateWithItems.postServiceStartIndex, undefined);
   });
 
   test('filters out Slide Group grouping items from serviceItems', async () => {
@@ -303,17 +304,23 @@ describe('proclaim service item indexing', () => {
     assert.ok(updateWithItems, 'Expected a state update with serviceItems');
 
     const items = updateWithItems.serviceItems;
-    assert.equal(items.length, 3, 'Should filter out Slide Group groupings but keep regular groupings');
+    assert.equal(items.length, 2, 'Should filter out both Slide Group and regular Grouping items');
     assert.ok(!items.find((i) => i.title === 'Slide Group'), 'Slide Group items should be filtered out');
-    assert.ok(items.find((i) => i.title === 'Worship'), 'Regular groupings should be included');
+    assert.ok(!items.find((i) => i.kind === 'Grouping'), 'All Grouping items should be filtered out');
 
-    // Slide Group at raw index 2 should be skipped; Worship is at raw index 3
-    const worshipItem = items.find((i) => i.title === 'Worship');
-    assert.equal(worshipItem.index, 3, 'Worship grouping should have raw index 3');
+    // Welcome is at raw index 1, no section indices → Pre-Service, no group
+    const welcomeItem = items.find((i) => i.title === 'Welcome');
+    assert.ok(welcomeItem, 'Welcome item should be present');
+    assert.equal(welcomeItem.index, 1);
+    assert.equal(welcomeItem.section, 'Pre-Service');
+    assert.equal(welcomeItem.group, null);
 
-    // Hymn is at raw index 4 (Slide Group at index 2 was excluded)
+    // Hymn is at raw index 4 (Slide Group at index 2 excluded, Worship at index 3 sets the group)
     const hymnItem = items.find((i) => i.title === 'Hymn');
+    assert.ok(hymnItem, 'Hymn should be present');
     assert.equal(hymnItem.index, 4, 'Hymn should retain its full-list index 4');
+    assert.equal(hymnItem.section, 'Pre-Service');
+    assert.equal(hymnItem.group, 'Worship', 'Hymn should be in the Worship group');
   });
 });
 


### PR DESCRIPTION
Implements #issue-25: Improve service overview

- Grouping items now appear as section headers in the Proclaim service item list
- Active item with multiple slides shows (x of y)
- Other items with multiple slides show (y slides)

Closes #25

Generated with [Claude Code](https://claude.ai/code)