### PR TITLE
feat: tray diagnostic logging and graceful shutdown

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -98,5 +98,5 @@ const url = `http://localhost:${port}`;
 server.listen(port, () => {
   logger.log(`[Server] Service Remote running at ${url}`);
   openBrowser(url);
-  startTray(port, state);
+  startTray(port, state, () => shutdown('tray'));
 });

--- a/src/tray.ps1
+++ b/src/tray.ps1
@@ -9,8 +9,12 @@
 #   { "event": "open" }
 #   { "event": "exit" }
 
+[Console]::Error.WriteLine('[Tray] PowerShell tray script starting')
+
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
+
+[Console]::Error.WriteLine('[Tray] Assemblies loaded')
 
 # Build a 16x16 solid-blue bitmap as the tray icon (no external file needed)
 function New-TrayIcon {
@@ -22,11 +26,13 @@ function New-TrayIcon {
 }
 
 $icon = New-TrayIcon
+[Console]::Error.WriteLine('[Tray] Tray icon created')
 
 $tray = New-Object System.Windows.Forms.NotifyIcon
 $tray.Icon = $icon
 $tray.Text = 'service-remote'
 $tray.Visible = $true
+[Console]::Error.WriteLine('[Tray] Tray icon set visible')
 
 # Context menu
 $menu = New-Object System.Windows.Forms.ContextMenuStrip
@@ -59,6 +65,7 @@ $exitItem.add_Click({
 $null = $menu.Items.Add($exitItem)
 
 $tray.ContextMenuStrip = $menu
+[Console]::Error.WriteLine('[Tray] Context menu configured')
 
 # Double-click also opens the browser
 $tray.add_DoubleClick({
@@ -70,11 +77,13 @@ $tray.add_DoubleClick({
 $stdin = [Console]::In
 $scriptBlock = {
     param($stdin, $statusItem, $tray, $menu)
+    [Console]::Error.WriteLine('[Tray] stdin reader thread started')
     while ($true) {
         $line = $stdin.ReadLine()
         if ($null -eq $line) { break }
         $line = $line.Trim()
         if ($line -eq '') { continue }
+        [Console]::Error.WriteLine("[Tray] stdin command: $line")
         try {
             $msg = $line | ConvertFrom-Json
         } catch { continue }
@@ -92,6 +101,7 @@ $scriptBlock = {
         }
     }
     # stdin closed — parent process gone
+    [Console]::Error.WriteLine('[Tray] stdin closed — exiting')
     $tray.Visible = $false
     [System.Windows.Forms.Application]::Exit()
 }
@@ -105,7 +115,9 @@ $ps.Runspace = $rs
 $null = $ps.AddScript($scriptBlock).AddArgument($stdin).AddArgument($statusItem).AddArgument($tray).AddArgument($menu)
 $null = $ps.BeginInvoke()
 
+[Console]::Error.WriteLine('[Tray] Starting Windows Forms message loop')
 [System.Windows.Forms.Application]::Run()
 
 $rs.Close()
 $tray.Dispose()
+[Console]::Error.WriteLine('[Tray] Message loop exited — script done')

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -7,19 +7,54 @@ import type { ChangeEvent } from './types';
 
 const { spawn, exec } = childProcess;
 
-function startTray(port: number, state: { on: (event: 'change', listener: (ev: ChangeEvent) => void) => void }): void {
-  if (process.platform !== 'win32') return;
+function startTray(
+  port: number,
+  state: { on: (event: 'change', listener: (ev: ChangeEvent) => void) => void },
+  shutdown: () => void
+): void {
+  logger.log(`[Tray] startTray called (platform: ${process.platform})`);
+
+  if (process.platform !== 'win32') {
+    logger.log('[Tray] Not Windows — skipping system tray');
+    return;
+  }
 
   const ps1 = path.join(__dirname, 'tray.ps1');
+  logger.log(`[Tray] Spawning PowerShell tray script: ${ps1}`);
+
   const child = spawn('powershell.exe', [
     '-NoProfile', '-NonInteractive', '-STA',
     '-ExecutionPolicy', 'Bypass',
     '-File', ps1,
   ], {
-    stdio: ['pipe', 'pipe', 'inherit'],
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  child.on('error', (err: Error) => logger.warn('[Tray] failed to start PowerShell:', err.message));
+  logger.log(`[Tray] PowerShell process spawned (pid: ${child.pid ?? 'unknown'})`);
+
+  child.on('error', (err: Error) => logger.warn('[Tray] Failed to start PowerShell:', err.message));
+
+  child.on('exit', (code: number | null, signal: string | null) => {
+    logger.log(`[Tray] PowerShell process exited (code: ${code}, signal: ${signal})`);
+  });
+
+  // Capture and log PowerShell stderr so errors appear in the log file
+  let errBuf = '';
+  child.stderr!.on('data', (chunk: Buffer) => {
+    errBuf += chunk.toString();
+    const lines = errBuf.split('\n');
+    errBuf = lines.pop()!;
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      // Diagnostic lines from tray.ps1 start with '[Tray]'; everything else is an unexpected PS error
+      if (trimmed.startsWith('[Tray]')) {
+        logger.log('[Tray] PS:', trimmed);
+      } else {
+        logger.warn('[Tray] PS error:', trimmed);
+      }
+    }
+  });
 
   // Parse newline-delimited JSON events from the tray process
   let buf = '';
@@ -30,19 +65,31 @@ function startTray(port: number, state: { on: (event: 'change', listener: (ev: C
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed) continue;
+      logger.log(`[Tray] Received: ${trimmed}`);
       let msg: { event?: string };
-      try { msg = JSON.parse(trimmed); } catch { continue; }
+      try { msg = JSON.parse(trimmed); } catch {
+        logger.warn('[Tray] Failed to parse tray message:', trimmed);
+        continue;
+      }
       if (msg.event === 'open') {
+        logger.log('[Tray] Opening browser');
         exec(`start http://localhost:${port}`);
       } else if (msg.event === 'exit') {
-        process.exit(0);
+        logger.log('[Tray] Exit requested from tray — shutting down');
+        shutdown();
+      } else {
+        logger.warn('[Tray] Unknown event from tray:', trimmed);
       }
     }
   });
 
   function send(obj: unknown): void {
-    if (!child.killed) {
-      child.stdin!.write(JSON.stringify(obj) + '\n');
+    if (!child.killed && child.exitCode === null) {
+      try {
+        child.stdin!.write(JSON.stringify(obj) + '\n');
+      } catch (err: unknown) {
+        logger.warn('[Tray] Failed to write to tray process:', err instanceof Error ? err.message : String(err));
+      }
     }
   }
 


### PR DESCRIPTION
Adds diagnostic logging to the Windows systray integration and fixes graceful shutdown when Exit is clicked.

Changes:
- Log platform, PS spawn, PID, events, and unexpected exits in tray.ts
- Capture PowerShell stderr via pipe so errors appear in the log file
- Call shutdown callback on tray exit instead of process.exit(0) directly
- Add [Console]::Error.WriteLine diagnostics to tray.ps1

Closes #30

Generated with [Claude Code](https://claude.ai/code)