### PR TITLE
build: hide console window on Windows ("--windows-hide-console")

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,12 +30,18 @@ fs.mkdirSync(dist, { recursive: true });
 const exeName = 'service-remote' + (process.platform === 'win32' ? '.exe' : '');
 const outfile = path.join(dist, exeName);
 
+// --windows-hide-console suppresses the terminal window so the tray app runs
+// silently in the background. The flag requires building natively on Windows
+// (it cannot be used when cross-compiling).
+const windowsFlags = process.platform === 'win32' ? ['--windows-hide-console'] : [];
+
 run(
   [
     'bun build',
     '--compile',
     '--minify',
     '--target=bun',
+    ...windowsFlags,
     'server.ts',
     `--outfile=${outfile}`,
   ].join(' ')


### PR DESCRIPTION
Adds `--windows-hide-console` to the `bun build --compile` invocation in `scripts/build.js`.

The compiled `service-remote.exe` runs as a system tray app, so the terminal window that Windows opens by default is unnecessary. This flag changes the executable to the Windows GUI subsystem so no console window appears on launch.

The flag is applied conditionally (`process.platform === 'win32'`) because Bun does not support it when cross-compiling.

Fixes #29

Generated with [Claude Code](https://claude.ai/code)