### PR TITLE
feat: pause connections when no web client is connected

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -83,15 +83,11 @@ if (Object.keys(embeddedPublic).length > 0) {
 }
 
 setupRoutes(app, { obs, x32, proclaim });
-setupWebSocket(server, state, x32);
+setupWebSocket(server, state, { obs, x32, proclaim });
 
 // Set up file logging next to config.json
 const logFile = path.join(path.dirname(config.userConfigPath), 'service-remote.log');
 logger.setLogFile(logFile);
-
-obs.connect();
-x32.connect();
-proclaim.connect();
 
 const port = config.server.port;
 const url = `http://localhost:${port}`;

--- a/src/connections/obs.ts
+++ b/src/connections/obs.ts
@@ -7,8 +7,10 @@ const OBSWebSocket = obsWebSocketJs.default;
 
 const obs = new OBSWebSocket();
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let wantConnected = false;
 
 async function connect(): Promise<void> {
+  wantConnected = true;
   if (reconnectTimer) clearTimeout(reconnectTimer);
   try {
     await obs.connect(config.obs.address, config.obs.password || undefined);
@@ -23,6 +25,7 @@ async function connect(): Promise<void> {
 }
 
 function scheduleReconnect(): void {
+  if (!wantConnected) return;
   if (reconnectTimer) clearTimeout(reconnectTimer);
   reconnectTimer = setTimeout(connect, 5000);
 }
@@ -30,7 +33,7 @@ function scheduleReconnect(): void {
 obs.on('ConnectionClosed', () => {
   logger.log('[OBS] Disconnected');
   state.update('obs', { connected: false });
-  scheduleReconnect();
+  if (wantConnected) scheduleReconnect();
 });
 
 obs.on('CurrentProgramSceneChanged', async ({ sceneName }) => {
@@ -174,6 +177,7 @@ function dbToMul(db: number): number {
 }
 
 function disconnect(): void {
+  wantConnected = false;
   if (reconnectTimer) {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;

--- a/src/connections/proclaim.ts
+++ b/src/connections/proclaim.ts
@@ -14,6 +14,7 @@ import type { ServiceItem } from '../types';
 let appCommandToken: string | null = null;
 let onAirSessionId: string | null = null;
 let connectionId: string | null = null;
+let wantConnected = false;
 
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -291,6 +292,7 @@ async function fetchDetailedStatus(): Promise<void> {
 }
 
 function scheduleReconnect(): void {
+  if (!wantConnected) return;
   if (reconnectTimer) return;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
@@ -299,6 +301,7 @@ function scheduleReconnect(): void {
 }
 
 async function connect(): Promise<void> {
+  wantConnected = true;
   try {
     appCommandToken = await authenticateAppCommand();
     logger.log('[Proclaim] Authenticated');
@@ -312,6 +315,7 @@ async function connect(): Promise<void> {
 }
 
 function disconnect(): void {
+  wantConnected = false;
   if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
   if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
   appCommandToken = null;

--- a/src/connections/x32.ts
+++ b/src/connections/x32.ts
@@ -9,6 +9,7 @@ const { Client, Server } = nodeOsc;
 let client: InstanceType<typeof Client> | null = null;
 let server: InstanceType<typeof Server> | null = null;
 let connected = false;
+let wantConnected = false;
 let keepAliveInterval: ReturnType<typeof setInterval> | null = null;
 let subscribeInterval: ReturnType<typeof setInterval> | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -33,6 +34,7 @@ const CH_COUNT = 32;
 const BUS_COUNT = 16;
 
 function connect(): void {
+  wantConnected = true;
   if (reconnectTimer) clearTimeout(reconnectTimer);
   if (keepAliveInterval) clearInterval(keepAliveInterval);
   if (subscribeInterval) clearInterval(subscribeInterval);
@@ -71,7 +73,7 @@ function connect(): void {
 
   // If we get responses, we're connected
   setTimeout(() => {
-    if (!connected) {
+    if (wantConnected && !connected) {
       logger.log('[X32] No response, will retry...');
       state.update('x32', { connected: false, channels });
       scheduleReconnect();
@@ -80,6 +82,7 @@ function connect(): void {
 }
 
 function scheduleReconnect(): void {
+  if (!wantConnected) return;
   if (reconnectTimer) clearTimeout(reconnectTimer);
   reconnectTimer = setTimeout(connect, 5000);
 }
@@ -244,6 +247,7 @@ function subscribeToChanges(): void {
 }
 
 function disconnect(): void {
+  wantConnected = false;
   if (keepAliveInterval) { clearInterval(keepAliveInterval); keepAliveInterval = null; }
   if (subscribeInterval) { clearInterval(subscribeInterval); subscribeInterval = null; }
   if (meterInterval) { clearInterval(meterInterval); meterInterval = null; }

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,36 +1,42 @@
 import ws = require('ws');
 import http = require('http');
+import type { Connections } from './types';
 
 const { WebSocketServer } = ws;
 
-interface MeterControl {
-  startMeterUpdates(): void;
-  stopMeterUpdates(): void;
-}
-
-function setupWebSocket(server: http.Server, state: ReturnType<typeof require>, x32?: MeterControl): void {
+function setupWebSocket(server: http.Server, state: ReturnType<typeof require>, connections?: Connections): void {
   const wss = new WebSocketServer({ server });
+
+  function openClientCount(): number {
+    let count = 0;
+    for (const client of wss.clients) {
+      if (client.readyState === 1 /* OPEN */) count++;
+    }
+    return count;
+  }
 
   wss.on('connection', (socket) => {
     // Send full state on connect
     socket.send(JSON.stringify({ type: 'state', data: state.get() }));
 
-    // Start meter updates when the first client connects
-    if (x32 && wss.clients.size === 1) {
-      x32.startMeterUpdates();
+    // Start connections when the first client connects
+    if (connections && wss.clients.size === 1) {
+      connections.obs.connect();
+      connections.x32.connect();
+      connections.proclaim.connect();
+      connections.x32.startMeterUpdates();
     }
 
     socket.on('close', () => {
-      if (!x32) return;
-      // Stop meter updates when the last client disconnects.
-      // The closing socket's readyState is CLOSED (3) at this point, so counting
-      // OPEN sockets gives the number of clients that remain connected.
-      let openCount = 0;
-      for (const client of wss.clients) {
-        if (client.readyState === 1 /* OPEN */) openCount++;
-      }
-      if (openCount === 0) {
-        x32.stopMeterUpdates();
+      if (!connections) return;
+      // Stop connections when the last client disconnects.
+      // The closing socket's readyState is CLOSED (3) at this point, so count
+      // OPEN sockets to find how many clients remain.
+      if (openClientCount() === 0) {
+        connections.x32.stopMeterUpdates();
+        connections.obs.disconnect();
+        connections.x32.disconnect();
+        connections.proclaim.disconnect();
       }
     });
   });

--- a/test/e2e/ws.test.ts
+++ b/test/e2e/ws.test.ts
@@ -157,3 +157,79 @@ describe('WebSocket meter subscription lifecycle', () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 });
+
+describe('WebSocket connection lifecycle', () => {
+  function waitForClose(socket: InstanceType<typeof wsModule.WebSocket>): Promise<void> {
+    return new Promise((resolve) => {
+      if (socket.readyState === wsModule.WebSocket.CLOSED) { resolve(); return; }
+      socket.once('close', resolve);
+      socket.close();
+    });
+  }
+
+  test('all connections are started when the first client connects', async () => {
+    const { server, calls } = createTestApp();
+    const testPort = await startServer(server);
+
+    const { ws } = await connectAndReceive(testPort);
+
+    assert.equal(calls.obs.connect, 1, 'obs.connect should be called once');
+    assert.equal(calls.x32.connect, 1, 'x32.connect should be called once');
+    assert.equal(calls.proclaim.connect, 1, 'proclaim.connect should be called once');
+
+    await waitForClose(ws);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test('connections are NOT started again when a second client connects', async () => {
+    const { server, calls } = createTestApp();
+    const testPort = await startServer(server);
+
+    const { ws: ws1 } = await connectAndReceive(testPort);
+    const { ws: ws2 } = await connectAndReceive(testPort);
+
+    assert.equal(calls.obs.connect, 1, 'obs.connect should only be called for the first client');
+    assert.equal(calls.x32.connect, 1, 'x32.connect should only be called for the first client');
+    assert.equal(calls.proclaim.connect, 1, 'proclaim.connect should only be called for the first client');
+
+    await waitForClose(ws1);
+    await waitForClose(ws2);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test('all connections are stopped when the last client disconnects', async () => {
+    const { server, calls } = createTestApp();
+    const testPort = await startServer(server);
+
+    const { ws } = await connectAndReceive(testPort);
+    await waitForClose(ws);
+
+    // Allow the server-side close event to propagate
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.equal(calls.obs.disconnect, 1, 'obs.disconnect should be called when last client leaves');
+    assert.equal(calls.x32.disconnect, 1, 'x32.disconnect should be called when last client leaves');
+    assert.equal(calls.proclaim.disconnect, 1, 'proclaim.disconnect should be called when last client leaves');
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test('connections are NOT stopped while other clients remain connected', async () => {
+    const { server, calls } = createTestApp();
+    const testPort = await startServer(server);
+
+    const { ws: ws1 } = await connectAndReceive(testPort);
+    const { ws: ws2 } = await connectAndReceive(testPort);
+
+    // Close only the first client
+    await waitForClose(ws1);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.equal(calls.obs.disconnect, undefined, 'obs.disconnect should not be called while ws2 is still open');
+    assert.equal(calls.x32.disconnect, undefined, 'x32.disconnect should not be called while ws2 is still open');
+    assert.equal(calls.proclaim.disconnect, undefined, 'proclaim.disconnect should not be called while ws2 is still open');
+
+    await waitForClose(ws2);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -76,7 +76,7 @@ function createTestApp(): TestApp {
   setupRoutes(app, stubs, state, testConfigPath);
 
   const server = http.createServer(app);
-  setupWebSocket(server, state, stubs.x32);
+  setupWebSocket(server, state, stubs);
 
   return { app, server, state, stubs, calls };
 }


### PR DESCRIPTION
Don't connect to OBS, X32, or Proclaim at server startup. Instead, start all connections when the first WebSocket client connects and disconnect them when the last client disconnects.

Adds a `wantConnected` guard to each connection module so that internal reconnect logic does not fire after an intentional disconnect.

Extends `setupWebSocket` to accept the full `Connections` object and manage the connection lifecycle alongside meter updates.

Closes #28

Generated with [Claude Code](https://claude.ai/code)