### PR TITLE
reduce log noise

### DIFF
--- a/src/connections/proclaim.ts
+++ b/src/connections/proclaim.ts
@@ -82,7 +82,6 @@ async function authenticateRemote(): Promise<{ onAirSessionId: string; connectio
     remoteDeviceName: '',
     password: config.proclaim.password,
   });
-  console.log('[Proclaim] auth/control OnAirSessionId:', sessionId);
   const controlRes = await fetch(`${baseUrl()}/auth/control`, {
     method: 'POST',
     headers: {
@@ -92,7 +91,6 @@ async function authenticateRemote(): Promise<{ onAirSessionId: string; connectio
     body: controlBody,
   });
   const controlText = await controlRes.text();
-  console.log('[Proclaim] auth/control response:', controlRes.status, controlText.slice(0, 300));
 
   if (!controlRes.ok) {
     // Likely running on the same machine as Proclaim — proceed with sessionId only
@@ -158,7 +156,6 @@ async function pollStatus(): Promise<void> {
     }
 
     const text = await res.text();
-    logger.log('[Proclaim] onair/session response:', JSON.stringify(text.trim().slice(0, 200)));
     const sessionId = text.trim();
     if (!sessionId || sessionId === 'null') {
       state.update('proclaim', {

--- a/src/connections/x32.ts
+++ b/src/connections/x32.ts
@@ -15,6 +15,7 @@ let subscribeInterval: ReturnType<typeof setInterval> | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let meterInterval: ReturnType<typeof setInterval> | null = null;
 let metersActive = false;
+let loggedNoResponse = false;
 
 interface OscArg {
   value: unknown;
@@ -74,7 +75,10 @@ function connect(): void {
   // If we get responses, we're connected
   setTimeout(() => {
     if (wantConnected && !connected) {
-      logger.log('[X32] No response, will retry...');
+      if (!loggedNoResponse) {
+        logger.log('[X32] No response, will retry...');
+        loggedNoResponse = true;
+      }
       state.update('x32', { connected: false, channels });
       scheduleReconnect();
     }
@@ -197,6 +201,7 @@ function handleMessage(msg: unknown[]): void {
 
   if (!connected) {
     connected = true;
+    loggedNoResponse = false;
     logger.log('[X32] Connected');
   }
 


### PR DESCRIPTION
Reduce noise from repetitive log messages:

- Remove `[Proclaim] onair/session response:` debug log that fired on every poll cycle
- Remove `console.log` calls for auth/control request/response details in proclaim.ts
- Only log `[X32] No response, will retry...` once per disconnect event (reset on reconnect)

Closes #27

Generated with [Claude Code](https://claude.ai/code)