### PR TITLE
feat(x32): sync DCA group 8 assignment to channel visibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -28,13 +28,13 @@ document.addEventListener('alpine:init', () => {
     isHiddenObs(name) { return this.hidden.obs.includes(name); },
     isHiddenX32(key) {
       // Main channels are always shown.
-      // All other channels are shown only when assigned to DCA group 8 (ch.dac8 === true).
+      // All other channels are shown only when assigned to DCA group 8 (ch.spill === true).
       const ch = Alpine.store('state').x32.channels.find(
         (c) => c.type + '/' + c.index === key
       );
       if (!ch) return true;
       if (ch.type === 'main') return false;
-      return !ch.dac8;
+      return !ch.spill;
     },
   });
 
@@ -307,13 +307,13 @@ function toggleHiddenX32(key, show) {
   // Optimistic update: reflect the change immediately in the local state so
   // the UI responds without waiting for the X32 to echo back the new DCA assignment.
   const ch = Alpine.store('state').x32.channels.find((c) => c.type + '/' + c.index === key);
-  if (ch && ch.type !== 'main') ch.dac8 = show;
+  if (ch && ch.type !== 'main') ch.spill = show;
 
   // Persist the DCA 8 assignment change to the X32 via the server.
   const parts = key.split('/');
   const type = parts[0];
   const channel = parseInt(parts[1], 10);
-  post('/api/x32/dac8', { channel, type, assigned: show });
+  post('/api/x32/spill', { channel, type, assigned: show });
 }
 
 let saveHiddenTimer = null;
@@ -338,7 +338,7 @@ async function loadHiddenFromServer() {
     const data = await res.json();
     const ui = Alpine.store('ui');
     ui.hidden.obs = data.hiddenObs || [];
-    // X32 visibility is driven by channel.dac8 (received via WebSocket from the X32),
+    // X32 visibility is driven by channel.spill (received via WebSocket from the X32),
     // not stored in config.
   } catch (_) {}
 }

--- a/src/connections/x32.ts
+++ b/src/connections/x32.ts
@@ -56,6 +56,9 @@ const pendingFaders = new Map<string, { value: number; sentAt: number }>();
 const PENDING_FADER_TIMEOUT_MS = 2000;
 const PENDING_FADER_TOLERANCE = 0.05;
 
+// OSC path suffix used for DCA group assignment messages (e.g. /ch/01/grp/dca)
+const DCA_GROUP_PATH = '/grp/dca';
+
 // Number of input channels, buses, and matrices on the X32
 const CH_COUNT = 32;
 const BUS_COUNT = 16;
@@ -86,16 +89,16 @@ function connect(): void {
   channels = [];
   dcaGroupsMap.clear();
   for (let i = 1; i <= CH_COUNT; i++) {
-    channels.push({ index: i, type: 'ch', label: `CH ${String(i).padStart(2, '0')}`, fader: 0, muted: false, level: 0, source: 0, linkedToNext: false, dac8: false });
+    channels.push({ index: i, type: 'ch', label: `CH ${String(i).padStart(2, '0')}`, fader: 0, muted: false, level: 0, source: 0, linkedToNext: false, spill: false});
   }
   for (let i = 1; i <= BUS_COUNT; i++) {
-    channels.push({ index: i, type: 'bus', label: `Bus ${String(i).padStart(2, '0')}`, fader: 0, muted: false, level: 0, source: 0, linkedToNext: false, dac8: false });
+    channels.push({ index: i, type: 'bus', label: `Bus ${String(i).padStart(2, '0')}`, fader: 0, muted: false, level: 0, source: 0, linkedToNext: false, spill: false});
   }
   for (let i = 1; i <= MTX_COUNT; i++) {
-    channels.push({ index: i, type: 'mtx', label: `Mtx ${String(i).padStart(2, '0')}`, fader: 0, muted: false, level: 0, source: 0, linkedToNext: false, dac8: false });
+    channels.push({ index: i, type: 'mtx', label: `Mtx ${String(i).padStart(2, '0')}`, fader: 0, muted: false, level: 0, source: 0, linkedToNext: false, spill: false});
   }
   for (const [idx, lbl] of Object.entries(MAIN_LABELS)) {
-    channels.push({ index: Number(idx), type: 'main', label: lbl, fader: 0, muted: false, level: 0, source: 1, linkedToNext: false, dac8: false });
+    channels.push({ index: Number(idx), type: 'main', label: lbl, fader: 0, muted: false, level: 0, source: 1, linkedToNext: false, spill: false});
   }
 
   // Bind to 0.0.0.0 so the OS accepts inbound packets on any local network
@@ -326,10 +329,10 @@ function sourcePatch(args: OscArg[]): Partial<Channel> {
 }
 
 // DCA group bitmask: bit 7 (value 128) = DCA group 8.
-// Returns { dac8: true } when bit 7 is set, { dac8: false } otherwise.
+// Returns { spill: true } when bit 7 is set, { spill: false } otherwise.
 function dcaPatch(args: OscArg[]): Partial<Channel> {
   const value = (args?.[0]?.value as number) ?? 0;
-  return { dac8: (value & 128) !== 0 };
+  return { spill: (value & 128) !== 0 };
 }
 
 const OSC_PATTERNS: OscPattern[] = [
@@ -338,12 +341,12 @@ const OSC_PATTERNS: OscPattern[] = [
   { re: /^\/ch\/(\d+)\/mix\/on$/,       type: 'ch',   indexGroup: 1, patch: mutePatch },
   { re: /^\/ch\/(\d+)\/config\/name$/,  type: 'ch',   indexGroup: 1, patch: namePatch },
   { re: /^\/ch\/(\d+)\/config\/source$/,type: 'ch',   indexGroup: 1, patch: sourcePatch },
-  { re: /^\/ch\/(\d+)\/grp\/dca$/,      type: 'ch',   indexGroup: 1, patch: dcaPatch },
+  { re: new RegExp(`^/ch/(\\d+)${DCA_GROUP_PATH}$`),  type: 'ch',   indexGroup: 1, patch: dcaPatch },
   // Mix buses
   { re: /^\/bus\/(\d+)\/mix\/fader$/,   type: 'bus',  indexGroup: 1, patch: faderPatch },
   { re: /^\/bus\/(\d+)\/mix\/on$/,      type: 'bus',  indexGroup: 1, patch: mutePatch },
   { re: /^\/bus\/(\d+)\/config\/name$/, type: 'bus',  indexGroup: 1, patch: namePatch },
-  { re: /^\/bus\/(\d+)\/grp\/dca$/,     type: 'bus',  indexGroup: 1, patch: dcaPatch },
+  { re: new RegExp(`^/bus/(\\d+)${DCA_GROUP_PATH}$`), type: 'bus',  indexGroup: 1, patch: dcaPatch },
   // Matrix
   { re: /^\/mtx\/(\d+)\/mix\/fader$/,   type: 'mtx',  indexGroup: 1, patch: faderPatch },
   { re: /^\/mtx\/(\d+)\/mix\/on$/,      type: 'mtx',  indexGroup: 1, patch: mutePatch },
@@ -391,11 +394,11 @@ function handleMessage(address: string, args: OscArg[]): void {
     for (let i = 1; i <= CH_COUNT; i++) {
       sendOsc(`${channelPrefix(i, 'ch')}/config/name`);
       sendOsc(`${channelPrefix(i, 'ch')}/config/source`);
-      sendOsc(`${channelPrefix(i, 'ch')}/grp/dca`);
+      sendOsc(`${channelPrefix(i, 'ch')}${DCA_GROUP_PATH}`);
     }
     for (let i = 1; i <= BUS_COUNT; i++) {
       sendOsc(`${channelPrefix(i, 'bus')}/config/name`);
-      sendOsc(`${channelPrefix(i, 'bus')}/grp/dca`);
+      sendOsc(`${channelPrefix(i, 'bus')}${DCA_GROUP_PATH}`);
     }
     for (let i = 1; i <= MTX_COUNT; i++) {
       sendOsc(`${channelPrefix(i, 'mtx')}/config/name`);
@@ -445,8 +448,8 @@ function handleMessage(address: string, args: OscArg[]): void {
   }
 
   // Intercept DCA group messages to store the full bitmask for read-modify-write.
-  // The parseOscMessage call below will also extract the dac8 boolean for the channel patch.
-  const dcaMatch = address.match(/^\/(ch|bus)\/(\d+)\/grp\/dca$/);
+  // The parseOscMessage call below will also extract the spill boolean for the channel patch.
+  const dcaMatch = address.match(new RegExp(`^/(ch|bus)/(\\d+)${DCA_GROUP_PATH}$`));
   if (dcaMatch) {
     const type = dcaMatch[1] as 'ch' | 'bus';
     const index = parseInt(dcaMatch[2], 10);
@@ -531,7 +534,7 @@ function subscribeToChanges(): void {
     ]);
     if (ch.type === 'ch' || ch.type === 'bus') {
       sendOsc('/subscribe', [
-        { value: `${prefix}/grp/dca` },
+        { value: `${prefix}${DCA_GROUP_PATH}` },
         { value: 20 },
       ]);
     }
@@ -605,14 +608,14 @@ export = {
     }
   },
 
-  setDac8(channelIndex: number, type: 'ch' | 'bus', assigned: boolean): void {
+  setSpill(channelIndex: number, type: 'ch' | 'bus', assigned: boolean): void {
     const key = `${type}-${channelIndex}`;
     const currentBitmask = dcaGroupsMap.get(key) ?? 0;
     const newBitmask = assigned ? (currentBitmask | 128) : (currentBitmask & ~128);
     dcaGroupsMap.set(key, newBitmask);
-    logger.log(`[X32] setDac8 ${type} ${channelIndex} = ${assigned} (bitmask ${newBitmask})`);
-    sendOsc(`${channelPrefix(channelIndex, type)}/grp/dca`, [{ value: newBitmask }]);
-    updateChannel(channelIndex, type, { dac8: assigned });
+    logger.log(`[X32] setSpill ${type} ${channelIndex} = ${assigned} (bitmask ${newBitmask})`);
+    sendOsc(`${channelPrefix(channelIndex, type)}${DCA_GROUP_PATH}`, [{ value: newBitmask }]);
+    updateChannel(channelIndex, type, { spill: assigned });
   },
 
   toggleMute(channelIndex: number, type: 'ch' | 'bus' | 'main' | 'mtx' = 'ch'): void {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -105,10 +105,10 @@ function setupRoutes(app: Application, { obs, x32, proclaim }: Connections, stat
     }
   });
 
-  app.post('/api/x32/dac8', (req: Request, res: Response) => {
+  app.post('/api/x32/spill', (req: Request, res: Response) => {
     try {
       const type = req.body.type === 'bus' ? 'bus' : 'ch';
-      x32.setDac8(req.body.channel, type, !!req.body.assigned);
+      x32.setSpill(req.body.channel, type, !!req.body.assigned);
       res.json({ ok: true });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface Channel {
   level: number; // Linear peak level 0.0–1.0 (updated when a WS client is connected)
   source: number; // Physical input source (0 = unpatched); only meaningful for 'ch'
   linkedToNext: boolean; // True if this channel is linked with the next (odd/even pair)
-  dac8: boolean; // True if assigned to DCA group 8 (shown in the soundboard UI)
+  spill: boolean; // True if assigned to DCA group 8 (shown in the soundboard UI)
 }
 
 export interface ServiceItem {
@@ -107,7 +107,7 @@ export interface X32Connection {
   parseOscMessage(address: string, args: Array<{ value: unknown }>): { index: number; type: 'ch' | 'bus' | 'main' | 'mtx'; patch: Partial<Channel> } | null;
   startMeterUpdates(): void;
   stopMeterUpdates(): void;
-  setDac8(channelIndex: number, type: 'ch' | 'bus', assigned: boolean): void;
+  setSpill(channelIndex: number, type: 'ch' | 'bus', assigned: boolean): void;
 }
 
 export interface ProclaimConnection {

--- a/test/e2e/api.test.ts
+++ b/test/e2e/api.test.ts
@@ -118,28 +118,28 @@ describe('API routes', () => {
     });
   });
 
-  describe('POST /api/x32/dac8', () => {
-    test('calls x32.setDac8 to assign a channel to DCA 8', async () => {
+  describe('POST /api/x32/spill', () => {
+    test('calls x32.setSpill to assign a channel to DCA 8', async () => {
       resetCalls();
-      const res = await request.post('/api/x32/dac8').send({ channel: 5, type: 'ch', assigned: true });
+      const res = await request.post('/api/x32/spill').send({ channel: 5, type: 'ch', assigned: true });
       assert.equal(res.status, 200);
       assert.deepEqual(res.body, { ok: true });
-      assert.deepEqual(calls.x32.setDac8, { channel: 5, type: 'ch', assigned: true });
+      assert.deepEqual(calls.x32.setSpill, { channel: 5, type: 'ch', assigned: true });
     });
 
-    test('calls x32.setDac8 to unassign a bus from DCA 8', async () => {
+    test('calls x32.setSpill to unassign a bus from DCA 8', async () => {
       resetCalls();
-      const res = await request.post('/api/x32/dac8').send({ channel: 2, type: 'bus', assigned: false });
+      const res = await request.post('/api/x32/spill').send({ channel: 2, type: 'bus', assigned: false });
       assert.equal(res.status, 200);
       assert.deepEqual(res.body, { ok: true });
-      assert.deepEqual(calls.x32.setDac8, { channel: 2, type: 'bus', assigned: false });
+      assert.deepEqual(calls.x32.setSpill, { channel: 2, type: 'bus', assigned: false });
     });
 
     test('defaults type to ch when not specified', async () => {
       resetCalls();
-      const res = await request.post('/api/x32/dac8').send({ channel: 3, assigned: true });
+      const res = await request.post('/api/x32/spill').send({ channel: 3, assigned: true });
       assert.equal(res.status, 200);
-      assert.deepEqual(calls.x32.setDac8, { channel: 3, type: 'ch', assigned: true });
+      assert.deepEqual(calls.x32.setSpill, { channel: 3, type: 'ch', assigned: true });
     });
   });
 

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -18,7 +18,7 @@ interface TestCalls {
   x32: {
     connect: number; disconnect: number; startMeterUpdates: number; stopMeterUpdates: number;
     setFader?: { channel: number; value: number }; toggleMute?: number;
-    setDac8?: { channel: number; type: string; assigned: boolean };
+    setSpill?: { channel: number; type: string; assigned: boolean };
   };
   proclaim: {
     connect: number; disconnect: number; startMeterUpdates: number; stopMeterUpdates: number;
@@ -68,7 +68,7 @@ function createTestApp(): TestApp {
       parseOscMessage: () => null,
       startMeterUpdates: () => { calls.x32.startMeterUpdates++; },
       stopMeterUpdates: () => { calls.x32.stopMeterUpdates++; },
-      setDac8: (channel: number, type: 'ch' | 'bus', assigned: boolean) => { calls.x32.setDac8 = { channel, type, assigned }; },
+      setSpill: (channel: number, type: 'ch' | 'bus', assigned: boolean) => { calls.x32.setSpill = { channel, type, assigned }; },
     },
     proclaim: {
       connect: async () => { calls.proclaim.connect++; },

--- a/test/ui/fixtures.ts
+++ b/test/ui/fixtures.ts
@@ -19,7 +19,7 @@ type AppState = {
   };
   x32?: {
     connected?: boolean;
-    channels?: { index: number; type: 'ch' | 'bus' | 'main' | 'mtx'; label: string; fader: number; muted: boolean; level: number; dac8?: boolean }[];
+    channels?: { index: number; type: 'ch' | 'bus' | 'main' | 'mtx'; label: string; fader: number; muted: boolean; level: number; spill?: boolean }[];
   };
   proclaim?: {
     connected?: boolean;

--- a/test/ui/x32.test.ts
+++ b/test/ui/x32.test.ts
@@ -1,9 +1,9 @@
 import { test, expect } from './fixtures';
 
 const channels = [
-  { index: 1, type: 'ch' as const, label: 'Vocals', fader: 0.8, muted: false, level: 0.5, dac8: true },
-  { index: 2, type: 'ch' as const, label: 'Guitar', fader: 0.5, muted: false, level: 0.3, dac8: true },
-  { index: 1, type: 'bus' as const, label: 'Main Bus', fader: 1.0, muted: false, level: 0.7, dac8: true },
+  { index: 1, type: 'ch' as const, label: 'Vocals', fader: 0.8, muted: false, level: 0.5, spill: true },
+  { index: 2, type: 'ch' as const, label: 'Guitar', fader: 0.5, muted: false, level: 0.3, spill: true },
+  { index: 1, type: 'bus' as const, label: 'Main Bus', fader: 1.0, muted: false, level: 0.7, spill: true },
 ];
 
 test.describe('Sound (X32) panel', () => {
@@ -74,9 +74,9 @@ test.describe('Sound (X32) panel', () => {
   });
 
   test('unchecking visibility hides a channel row after leaving edit mode', async ({ page, setState }) => {
-    let dac8Call: { channel: number; type: string; assigned: boolean } | null = null;
-    await page.route('**/api/x32/dac8', async (route) => {
-      dac8Call = route.request().postDataJSON();
+    let spillCall: { channel: number; type: string; assigned: boolean } | null = null;
+    await page.route('**/api/x32/spill', async (route) => {
+      spillCall = route.request().postDataJSON();
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) });
     });
 
@@ -95,27 +95,27 @@ test.describe('Sound (X32) panel', () => {
     await expect(rows.nth(1)).toBeVisible();
 
     // Verify the API call was made
-    expect(dac8Call).not.toBeNull();
-    expect(dac8Call!.assigned).toBe(false);
+    expect(spillCall).not.toBeNull();
+    expect(spillCall!.assigned).toBe(false);
   });
 
-  test('channels with dac8:false are hidden, dac8:true are shown', async ({ page, setState }) => {
+  test('channels with spill:false are hidden, spill:true are shown', async ({ page, setState }) => {
     const mixedChannels = [
-      { index: 1, type: 'ch' as const, label: 'Vocals', fader: 0.8, muted: false, level: 0.5, dac8: true },
-      { index: 2, type: 'ch' as const, label: 'Guitar', fader: 0.5, muted: false, level: 0.0, dac8: false },
-      { index: 1, type: 'bus' as const, label: 'Main Bus', fader: 0.7, muted: false, level: 0.0, dac8: false },
-      { index: 1, type: 'main' as const, label: 'Main L/R', fader: 0.9, muted: false, level: 0.6, dac8: false },
+      { index: 1, type: 'ch' as const, label: 'Vocals', fader: 0.8, muted: false, level: 0.5, spill: true },
+      { index: 2, type: 'ch' as const, label: 'Guitar', fader: 0.5, muted: false, level: 0.0, spill: false },
+      { index: 1, type: 'bus' as const, label: 'Main Bus', fader: 0.7, muted: false, level: 0.0, spill: false },
+      { index: 1, type: 'main' as const, label: 'Main L/R', fader: 0.9, muted: false, level: 0.6, spill: false },
     ];
 
     await setState({ x32: { connected: true, channels: mixedChannels } });
 
     const p = panel(page);
-    // dac8:true channel is visible
+    // spill:true channel is visible
     await expect(p.locator('.channel-row-h').filter({ hasText: 'Vocals' })).toBeVisible();
-    // dac8:false channels are hidden
+    // spill:false channels are hidden
     await expect(p.locator('.channel-row-h').filter({ hasText: 'Guitar' })).not.toBeVisible();
     await expect(p.locator('.channel-row-h').filter({ hasText: 'Main Bus' })).not.toBeVisible();
-    // main type is always shown regardless of dac8
+    // main type is always shown regardless of spill
     await expect(p.locator('.channel-row-h').filter({ hasText: 'Main L/R' })).toBeVisible();
   });
 

--- a/test/unit/x32.test.ts
+++ b/test/unit/x32.test.ts
@@ -163,44 +163,44 @@ describe('x32 parseOscMessage()', () => {
   });
 
   describe('DCA group messages (/ch/XX/grp/dca and /bus/XX/grp/dca)', () => {
-    test('ch dca bitmask with bit 7 set → dac8: true', () => {
+    test('ch dca bitmask with bit 7 set → spill: true', () => {
       const result = parseOscMessage('/ch/01/grp/dca', [{ value: 128 }]);
-      assert.deepEqual(result, { index: 1, type: 'ch', patch: { dac8: true } });
+      assert.deepEqual(result, { index: 1, type: 'ch', patch: { spill: true } });
     });
 
-    test('ch dca bitmask with bit 7 clear → dac8: false', () => {
+    test('ch dca bitmask with bit 7 clear → spill: false', () => {
       const result = parseOscMessage('/ch/01/grp/dca', [{ value: 0 }]);
-      assert.deepEqual(result, { index: 1, type: 'ch', patch: { dac8: false } });
+      assert.deepEqual(result, { index: 1, type: 'ch', patch: { spill: false } });
     });
 
-    test('ch dca bitmask with multiple bits set including bit 7 → dac8: true', () => {
+    test('ch dca bitmask with multiple bits set including bit 7 → spill: true', () => {
       const result = parseOscMessage('/ch/05/grp/dca', [{ value: 136 }]); // 128 + 8 = DCA 4 + DCA 8
-      assert.deepEqual(result, { index: 5, type: 'ch', patch: { dac8: true } });
+      assert.deepEqual(result, { index: 5, type: 'ch', patch: { spill: true } });
     });
 
-    test('ch dca bitmask with only lower bits set → dac8: false', () => {
+    test('ch dca bitmask with only lower bits set → spill: false', () => {
       const result = parseOscMessage('/ch/03/grp/dca', [{ value: 7 }]); // DCA 1+2+3 only
-      assert.deepEqual(result, { index: 3, type: 'ch', patch: { dac8: false } });
+      assert.deepEqual(result, { index: 3, type: 'ch', patch: { spill: false } });
     });
 
-    test('missing args defaults to dac8: false', () => {
+    test('missing args defaults to spill: false', () => {
       const result = parseOscMessage('/ch/02/grp/dca', []);
-      assert.deepEqual(result, { index: 2, type: 'ch', patch: { dac8: false } });
+      assert.deepEqual(result, { index: 2, type: 'ch', patch: { spill: false } });
     });
 
-    test('bus dca bitmask with bit 7 set → dac8: true', () => {
+    test('bus dca bitmask with bit 7 set → spill: true', () => {
       const result = parseOscMessage('/bus/03/grp/dca', [{ value: 128 }]);
-      assert.deepEqual(result, { index: 3, type: 'bus', patch: { dac8: true } });
+      assert.deepEqual(result, { index: 3, type: 'bus', patch: { spill: true } });
     });
 
-    test('bus dca bitmask with bit 7 clear → dac8: false', () => {
+    test('bus dca bitmask with bit 7 clear → spill: false', () => {
       const result = parseOscMessage('/bus/16/grp/dca', [{ value: 64 }]);
-      assert.deepEqual(result, { index: 16, type: 'bus', patch: { dac8: false } });
+      assert.deepEqual(result, { index: 16, type: 'bus', patch: { spill: false } });
     });
 
     test('two-digit channel', () => {
       const result = parseOscMessage('/ch/32/grp/dca', [{ value: 128 }]);
-      assert.deepEqual(result, { index: 32, type: 'ch', patch: { dac8: true } });
+      assert.deepEqual(result, { index: 32, type: 'ch', patch: { spill: true } });
     });
   });
 });


### PR DESCRIPTION
Closes #42

Replace the manual `hiddenX32` config system with bidirectional sync to the X32’s DCA group 8 assignment. Channels assigned to DCA 8 on the mixer are shown in the soundboard UI; others are hidden. Changes on either side propagate bidirectionally.

## Changes

- Add `dac8: boolean` to Channel type (true = shown in soundboard)
- Track full DCA bitmask per channel for safe bit operations
- Handle `/ch/XX/grp/dca` and `/bus/XX/grp/dca` OSC messages
- Request DCA group state on connect; subscribe to live changes
- Export `setDac8()` to toggle bit 7 on the mixer via OSC
- Add `POST /api/x32/dac8` route
- Update `isHiddenX32()` to use `channel.dac8` (main type always shown)
- `toggleHiddenX32()` does optimistic update + calls `/api/x32/dac8`
- Remove `shownDefaultX32` and `hiddenX32` client-side state

Generated with [Claude Code](https://claude.ai/code)